### PR TITLE
Add error handling.

### DIFF
--- a/alan.c
+++ b/alan.c
@@ -21,7 +21,7 @@
 #define COMMENT_CHAR '!'
 #define CONFIGURATION_COUNT MAX_CONF
 #define CONFIGURATION_LENGTH 32
-#define NOLINE -1
+#define NOLINE -1 // Used for error handling to signify that the error does not belong to any line (for instance file reading errors, internal errors etc).
 #define WINDOWSIZE 64
 
 typedef enum Op { N = 0, P, E, R, L } Op;

--- a/alan.c
+++ b/alan.c
@@ -55,6 +55,11 @@ typedef struct Machine {
 
 } Machine;
 
+void Error(const char *msg) {
+    fprintf(stderr,"%s\n", msg);
+    exit(EXIT_FAILURE);
+}
+
 char *ReadSource(char *filename) {
 
     // https://www.tutorialspoint.com/cprogramming/c_file_io.htm

--- a/alan.c
+++ b/alan.c
@@ -119,21 +119,6 @@ char *trim(char *str) {
 
     return str;
 }
-char *tokenize(char *input, char delim, char *context) {
-    if(input != NULL) {
-        strcpy(context, input);
-    }
-    int count = 0;
-    for (int i = 0; i < 1000; i++) {
-        if (context[i] == delim) {
-            char *result = (char*) malloc (i+1);
-            memcpy(result, context, i);
-            result[i] = 0;
-            strcpy(context, context + i + 1);
-            return trim(result);
-        }
-    }
-}
 
 void error(Context *c, char *msg, int line) {
     c->error = true;
@@ -602,17 +587,6 @@ void RunMachine(Machine *m, int iterations, char *result, bool verbose) {
 
 
 int main(int argc, char *argv[]) {
-
-    char context[128];
-    char *testString = "  first   :   second   : last";
-    char delim = ':';
-
-    char *res1 = tokenize(testString, delim, context);
-    printf("'%s', '%s'\n", res1, context);
-    free(res1);
-    char *res2 = tokenize(NULL, delim, context);
-    printf("'%s', '%s'\n", res2, context);
-    free(res2);
 
     Context c = {0};
 


### PR DESCRIPTION
Currently handles error in file reading, missing configuration name, missing match symbol and missing 'next'-value.
Closes #17.