### PR TITLE
Parser rewrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # personal
-build.bat
-shell.bat
 .clang-format
+dev.bat
 
 # for the project
 *.exe

--- a/Makefile
+++ b/Makefile
@@ -9,5 +9,8 @@ endif
 $(target): alan.c
 	clang -o $(target) alan.c $(link)
 
+debug: alan.c
+	clang alan.c -g -gcodeview -o build/$(target)
+
 clean:
 	rm -f turing.o

--- a/alan.c
+++ b/alan.c
@@ -492,17 +492,13 @@ IR *parse(Context *c, IR *ir, char *code) {
                           } break;
                 case 'R': {
                               if (isdigit(*param)) {
-                                  // TODO error
+                                  branch->ops[i].number = *param - 48;
                               }
-                              branch->ops[i].isNum = true;
-                              branch->ops[i].number = *param - 48;
                           } break;
                 case 'L': {
                               if (isdigit(*param)) {
-                                  // TODO error
+                                  branch->ops[i].number = *param - 48;
                               }
-                              branch->ops[i].isNum = true;
-                              branch->ops[i].number = *param - 48;
                           } break;
                 default: {
                              // TODO Feil
@@ -583,56 +579,57 @@ void copy_n(size_t SourceACount, char *SourceA, size_t DestCount, char *Dest) {
     *Dest++ = 0;
 }
 
-/*
-   void PrintMachine(Machine *m, int topPointerAccessed, int lowerBound,
-   int upperBound, bool verbose) {
-   char outputBuffer[TAPE_LENGTH];  // Buffer used for printing
-   char pointerBuffer[TAPE_LENGTH];
+void print_machine(Machine *m, int topPointerAccessed) {
+    //int upperBound, bool verbose) {
+    char outputBuffer[TAPE_LENGTH];  // Buffer used for printing
+    char pointerBuffer[TAPE_LENGTH];
 
-   int pointer = (m->pointer == 0) ? 1 : m->pointer;
+    int pointer = m->pointer + 1;
 
-   for (int i = 0; i <= pointer; i++) {
-   pointerBuffer[i] = ' ';
-   }
+    for (int i = 0; i <= pointer; i++) {
+        pointerBuffer[i] = ' ';
+    }
 
-// On the first pass the pointer will be set to 0, but
-// we want it to point on a blank space in the tape
-strcpy(outputBuffer, m->tape);
-outputBuffer[topPointerAccessed + 1] = '\0';
+    // On the first pass the pointer will be set to 0, but
+    // we want it to point on a blank space in the tape
+    strcpy(outputBuffer, m->tape);
+    outputBuffer[topPointerAccessed ] = '\0';
 
-pointerBuffer[pointer - lowerBound + 1] = 'v';
-pointerBuffer[pointer - lowerBound + 2] = '\0';
+    pointerBuffer[pointer + 1] = 'v';
+    pointerBuffer[pointer + 2] = '\0';
+    /*
+    // TODO test for bad size
+    if (lowerBound != -1 || upperBound != -1) {
+    char boundBuffer[WINDOWSIZE + 1];
+    outputBuffer[upperBound] = 0;
+    strcpy(boundBuffer, outputBuffer + lowerBound);
+    strcpy(outputBuffer, boundBuffer);
 
-// TODO test for bad size
-if (lowerBound != -1 || upperBound != -1) {
-char boundBuffer[WINDOWSIZE + 1];
-outputBuffer[upperBound] = 0;
-strcpy(boundBuffer, outputBuffer + lowerBound);
-strcpy(outputBuffer, boundBuffer);
+    outputBuffer[lowerBound + upperBound] = '\0';
+    }
+    */
+    // verbose
+    if (true) {
+        Configuration *c = &m->configurations[m->configuration];
+        Branch *b = &c->branches[m->branch];
 
-outputBuffer[lowerBound + upperBound] = '\0';
+        char leftLimit = '[';
+        char rightLimit = ']';
+        /*
+           if (upperBound < topPointerAccessed) {
+           rightLimit = '>';
+           }
+           if (lowerBound > 0) {
+           leftLimit = '<';
+           }
+           */
+        printf("%s\n", outputBuffer);
+        //printf("> %c | %s\n%s\n%c%s%c\n\n\n", b->matchSymbol,
+        //       b->nextConfiguration, pointerBuffer, leftLimit, outputBuffer, rightLimit);
+    } else {
+        printf("%s \n[%s]\n\n", pointerBuffer, outputBuffer);
+    }
 }
-
-if (verbose) {
-Configuration *c = &m->configurations[m->configuration];
-Branch *b = &c->branch[m->branch];
-
-char leftLimit = '[';
-char rightLimit = ']';
-if (upperBound < topPointerAccessed) {
-rightLimit = '>';
-}
-if (lowerBound > 0) {
-leftLimit = '<';
-}
-
-printf("> %s:%s | %s | %s\n%s\n%c%s%c\n\n\n", c->name, b->symbol, b->ops,
-b->next, pointerBuffer, leftLimit, outputBuffer, rightLimit);
-} else {
-printf("%s \n[%s]\n\n", pointerBuffer, outputBuffer);
-}
-}
-*/
 
 void run_machine(Context *context, Machine *m, int iterations, char *result,
         bool verbose) {
@@ -704,12 +701,13 @@ void run_machine(Context *context, Machine *m, int iterations, char *result,
                     lowBound = highBound - window;
                 }
             }
+            //print_machine(m, topPointerAccessed, lowBound, highBound,
+            print_machine(m, topPointerAccessed);
             /*
-            if (verbose) {
-                PrintMachine(m, topPointerAccessed, lowBound, highBound,
-                true);
-            }
-            */
+               if (verbose) {
+               true);
+               }
+               */
             m->configuration = branch.nextConfiguration;
             break;
         }
@@ -730,6 +728,10 @@ void run_machine(Context *context, Machine *m, int iterations, char *result,
 
 Machine translate(IR *ir) {
     Machine m;
+
+    for (int i = 0; i < TAPE_LENGTH; i++) {
+        m.tape[i] = NONE;
+    }
 
     for (int ci = 0; ci < ir->configCount; ci++) {
         Configuration *conf = &m.configurations[ci];
@@ -780,10 +782,15 @@ Machine translate(IR *ir) {
                     case 'R': {
                                   op->name = R;
                                   op->number = iop.number;
+                                  if (iop.number == 0) {
+                                      op->number = 1;
+                                  }
                               } break;
                     case 'L': {
                                   op->name = L;
-                                  op->number = (int)iop.number;
+                                  if (iop.number == 0) {
+                                      op->number = 1;
+                                  }
                               } break;
                 }
             }

--- a/alan.c
+++ b/alan.c
@@ -1,698 +1,765 @@
 #define _CRT_SECURE_NO_WARNINGS 1
-#if defined(_MSC_VER) // Check if we are using a windows compiler
+#if defined(_MSC_VER)  // Check if we are using a windows compiler
 #define strtok_r strtok_s
 #endif
 
-#include <stdint.h>
+#include <assert.h>
+#include <ctype.h>
+#include <math.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
-#include <assert.h>
-#include <math.h>
+
+#include "alan.h"
 
 #define TAPE_LENGTH 256
-#define MAX_BRANCH_COUNT 8
+#define MAX_BRANCH_COUNT 32
 #define MAX_OPERATION_COUNT 16
-#define MAX_CONF 16
-#define NONE ' '
-#define ELSE 0xff
-#define COMMENT_CHAR '!'
-#define CONFIGURATION_COUNT MAX_CONF
-#define CONFIGURATION_LENGTH 32
-#define WINDOWSIZE 64
-
+#define MAX_CONF_COUNT 32
 #define MAX_ERROR 8
+
+#define NONE ' '
+#define COMMENT_CHAR '!'
+#define ELSE 0xff
+
+#define WINDOWSIZE 32
+
 #define ARGUMENT_ERROR -1
 #define FILE_ERROR -2
 
+#define NOT_DEFINED -1
+
+/*
+ * Here we define the structures that encompass the
+ * bytecode that the source will be translated to,
+ * and which will be executed on the virtual
+ * machine.
+ */
+
 typedef enum Op { N = 0, P, E, R, L } Op;
 
-typedef struct Operation {
-    Op op;
-    char parameter;
-    char varParameter[64];
+// TODO
+// https://en.wikipedia.org/wiki/Flexible_array_member
 
+typedef struct Operation {
+  Op op;
+  union {
+    char *string;
+    int number;
+  } parameter;
 } Operation;
 
 typedef struct Branch {
-    char symbol[32];
-    char next[32];
-    char ops[64];
-    int matchSymbol;
-    int nextConfiguration;
-    Operation operations[MAX_OPERATION_COUNT];
-
+  char matchSymbol;
+  int nextConfiguration;
+  Operation operations[MAX_OPERATION_COUNT];
 } Branch;
 
 typedef struct Configuration {
-    char name[256];
-    Branch branch[MAX_BRANCH_COUNT];
-
+  Branch branch[MAX_BRANCH_COUNT];
 } Configuration;
 
 typedef struct Machine {
-    int pointer;
-    char tape[TAPE_LENGTH];
+  int pointer;
+  char tape[TAPE_LENGTH];
 
-    int configuration;
-    int branch;
-    Configuration configurations[MAX_CONF];
+  int configuration;
+  int branch;
+  Configuration configurations[MAX_CONF_COUNT];
 
 } Machine;
 
+/*
+ * Here we define structures used for the intermediary representation
+ * of the turing program, which helps us detect errors at parse-time,
+ * and allows us to print detailed information at runtime.
+ */
+typedef struct IOperation {
+  char op;
+  bool isnum;  // True if num, false if string
+  union {
+    char *string;
+    int number;
+  } parameter;
+} IOperation;
+
+typedef struct IBranch {
+  int definedOn;
+  char *matchSymbol;
+  IConfig *next;
+  IOperation ops[MAX_OPERATION_COUNT];
+} IBranch;
+
+typedef struct IConfig {
+  int definedOn;
+  bool defined;
+  char *name;
+  IBranch branches[MAX_BRANCH_COUNT];
+} IConfig;
+
+typedef struct IR {
+  IConfig configs[MAX_CONF_COUNT];
+} IR;
+
 typedef struct Error {
-    char message[64];
-    int line;
+  char *message;
+  int line;
 } Error;
 
 typedef struct Context {
-    bool error;
-    bool errorOverflow;
-    int nextError;
-    Error errors[MAX_ERROR];
+  IR parseInfo;
+
+  bool error;
+  bool errorOverflow;
+  int nextError;
+  Error errors[MAX_ERROR];
 } Context;
 
-typedef struct ConfigDefHelper {
-    bool defined;
-    char configName[CONFIGURATION_LENGTH];
-} ConfigDefHelper;
-
 char *trim(char *str) {
-    // TODO Write a simpler version of this
-    // https://stackoverflow.com/questions/122616/how-do-i-trim-leading-trailing-whitespace-in-a-standard-way
-    size_t len = 0;
-    char *frontp = str;
-    char *endp = NULL;
+  // TODO Write a simpler version of this
+  // https://stackoverflow.com/questions/122616/how-do-i-trim-leading-trailing-whitespace-in-a-standard-way
+  size_t len = 0;
+  char *frontp = str;
+  char *endp = NULL;
 
-    if (str == NULL) {
-        return NULL;
-    }
-    if (str[0] == '\0') {
-        return str;
-    }
-
-    len = strlen(str);
-    endp = str + len;
-
-    /* Move the front and back pointers to address the first non-whitespace
-     * characters from each end.
-     */
-    while (isspace((unsigned char)*frontp)) {
-        ++frontp;
-    }
-    if (endp != frontp) {
-        while (isspace((unsigned char)*(--endp)) && endp != frontp) {
-        }
-    }
-
-    if (frontp != str && endp == frontp)
-        *str = '\0';
-    else if (str + len - 1 != endp)
-        *(endp + 1) = '\0';
-
-    /* Shift the string so that it starts at str so that if it's dynamically
-     * allocated, we can still free it on the returned pointer.  Note the reuse
-     * of endp to mean the front of the string buffer now.
-     */
-    endp = str;
-    if (frontp != str) {
-        while (*frontp) {
-            *endp++ = *frontp++;
-        }
-        *endp = '\0';
-    }
-
+  if (str == NULL) {
+    return NULL;
+  }
+  if (str[0] == '\0') {
     return str;
+  }
+
+  len = strlen(str);
+  endp = str + len;
+
+  /* Move the front and back pointers to address the first non-whitespace
+   * characters from each end.
+   */
+  while (isspace((unsigned char)*frontp)) {
+    ++frontp;
+  }
+  if (endp != frontp) {
+    while (isspace((unsigned char)*(--endp)) && endp != frontp) {
+    }
+  }
+
+  if (frontp != str && endp == frontp)
+    *str = '\0';
+  else if (str + len - 1 != endp)
+    *(endp + 1) = '\0';
+
+  /* Shift the string so that it starts at str so that if it's dynamically
+   * allocated, we can still free it on the returned pointer.  Note the reuse
+   * of endp to mean the front of the string buffer now.
+   */
+  endp = str;
+  if (frontp != str) {
+    while (*frontp) {
+      *endp++ = *frontp++;
+    }
+    *endp = '\0';
+  }
+
+  return str;
 }
 
 void error(Context *c, char *msg, int line) {
-    c->error = true;
-    if(c->nextError < MAX_ERROR) {
-        // TODO bound check and assert
-        strcpy(c->errors[c->nextError].message, msg);
-        c->errors[c->nextError].line = line;
-        c->nextError++;
+  c->error = true;
+  if (c->nextError < MAX_ERROR) {
+    // TODO bound check and assert
+    c->errors[c->nextError].message = msg;
+    c->errors[c->nextError].line = line;
+    c->nextError++;
+  } else {
+    c->errorOverflow = true;
+  }
+}
+
+void handle_errors(Context *c) {
+  for (int i = 0; i < c->nextError; i++) {
+    int line = c->errors[i].line;
+    char *msg = c->errors[i].message;
+    if (line == FILE_ERROR) {
+      fprintf(stderr, "\n\tFile error:\n\t  %s\n", msg);
+    } else if (line == ARGUMENT_ERROR) {
+      fprintf(stderr, "\n\tArgument error:\n\t  %s\n", msg);
     } else {
-        c->errorOverflow = true;
+      fprintf(stderr, "\n\tError in line %i:\n\t  %s\n", ++line, msg);
     }
-
-}
-
-void handleErrors(Context *c) {
-    for(int i = 0; i < c->nextError; i++) {
-        int line = c->errors[i].line;
-        char *msg = c->errors[i].message;
-        if (line == FILE_ERROR) {
-            fprintf(stderr,"\n\tFile error:\n\t  %s\n", msg);
-        } else if (line == ARGUMENT_ERROR){
-            fprintf(stderr,"\n\tArgument error:\n\t  %s\n", msg);
-        } else {
-            fprintf(stderr,"\n\tError in line %i:\n\t  %s\n", ++line, msg);
-        }
-    }
+  }
+  if (c->error) {
     exit(EXIT_FAILURE);
-
-
+  }
 }
 
+char *read_source(Context *c, char *filename) {
+  // https://www.tutorialspoint.com/cprogramming/c_file_io.htm
+  FILE *file =
+      fopen(filename, "rb");  // TODO Might be problematic outside of windows
+  if (!file) {
+    error(c, "File could not be loaded. Does it exist?", FILE_ERROR);
+    return 0;
+  };
+  fseek(file, 0, SEEK_END);
+  long fsize = ftell(file);
+  fseek(file, 0, SEEK_SET);
 
-char *ReadSource(Context *c, char *filename) {
+  char *bytecode = (char *)malloc(fsize + 1);
+  fread(bytecode, fsize, 1, file);
+  fclose(file);
+  bytecode[fsize] = 0;  // Add line-terminator
 
-    // https://www.tutorialspoint.com/cprogramming/c_file_io.htm
-    FILE *file = fopen(filename, "rb");  // TODO Might be problematic outside of windows
-    if(!file) {
-        error(c, "File could not be loaded. Does it exist?", FILE_ERROR);
-        return 0;
-    };
-    fseek(file, 0, SEEK_END);
-    long fsize = ftell(file);
-    fseek(file, 0, SEEK_SET);
-
-    char *bytecode = (char *)malloc(fsize + 1);
-    fread(bytecode, fsize, 1, file);
-    fclose(file);
-    bytecode[fsize] = 0;  // Add line-terminator
-
-    return bytecode;
+  return bytecode;
 }
 
-float ParseBinaryPointValue(char *numstring) {
-    float sum = 0;
-    char *c = numstring;
-    float n = 1;
+float parse_binary_point_value(char *numstring) {
+  float sum = 0;
+  char *c = numstring;
+  float n = 1;
 
-    while(*c != '\0') {
-        float i = (float)(*c++-48);
-        sum += i * 1.0f/powf(2.0f, n);
-        n *= 2;
+  while (*c != '\0') {
+    float i = (float)(*c++ - 48);
+    sum += i * 1.0f / powf(2.0f, n);
+    n *= 2;
+  }
+
+  return sum;
+}
+
+char *parse_string(char *result, char *binary) {
+  char *c = binary;
+  int resultIndex = 0;
+  while (*c != 0) {
+    int n = 128;
+    char sum = 0;
+    for (int i = 0; i < 8; i++) {
+      if (*c == 0) {
+        break;
+      }
+      if (*c == '1') {
+        assert(n < 0xff);
+        sum += (char)n * 1;
+      }
+      n /= 2;
+      c++;
     }
-
-    return sum;
+    result[resultIndex++] = sum;
+  }
+  return result;
 }
 
-char *ParseBinaryString(char *result, char *binary) {
-    char *c = binary;
-    int resultIndex = 0;
-    while(*c != 0) {
-        int n = 128;
-        char sum = 0;
-        for(int i = 0; i < 8; i++) {
-            if(*c == 0) {
-                break;
-            }
-            if(*c == '1') {
-                assert(n < 0xff);
-                sum += (char)n * 1;
-            }
-            n /= 2;
-            c++;
-        }
-        result[resultIndex++] = sum;
+int insert_config(IConfig array[MAX_CONF_COUNT], char *str) {
+  for (int i = 0; i < MAX_CONF_COUNT; i++) {
+    if (array[i].name == NULL) {
+      // We have found an empty spot,
+      // which means the identifier is not in the list,
+      // so we put it here
+      // TODO handle bas size
+      array[i].name = str;
+      return i;
+
+    } else if (strcmp(array[i].name, str) == 0) {
+      // The identifier already exists, so we return its return index
+      return i;
     }
-    return result;
+    continue;
+  }
+  assert(false);
+  return -1;
 }
 
-
-int insertConfig(ConfigDefHelper array[CONFIGURATION_COUNT], char *str) {
-    for (int i = 0; i < CONFIGURATION_COUNT; i++) {
-        if (array[i].configName[0] == 0) {
-            // We have found an empty spot,
-            // which means the identifier is not in the list,
-            // so we put it here
-            // TODO handle bas size
-            strcpy(array[i].configName, str);
-            return i;
-
-        } else if (strcmp(array[i].configName, str) == 0) {
-
-            // The identifier already exists, so we return its return index
-            return i;
-        }
+int find_config(IConfig array[MAX_CONF_COUNT], char *str) {
+  for (int i = 0; i < MAX_CONF_COUNT; i++) {
+    if(array[i].name == NULL) {
         continue;
     }
-    assert(false);
-    return -1;
-}
-int findConfig(ConfigDefHelper array[CONFIGURATION_COUNT], char *str) {
-    for (int i = 0; i < CONFIGURATION_COUNT; i++) {
-        if (strcmp(array[i].configName, str) == 0) {
+    if (strcmp(array[i].name, str) == 0) {
 
-            // The identifier already exists, so we return its return index
-            return i;
-        }
-        continue;
+      // The identifier already exists, so we return its return index
+      return i;
     }
-    return -1;
+    continue;
+  }
+  return -1;
 }
 
-int splitOn(char *slots[], char *text, char *delimiter) {
-    char *context;
+int split_on(char *slots[], char *text, char *delimiter) {
+  char *context;
 
-    int index = 0;
-    char *unit = strtok_r(text, delimiter, &context);
-    while (unit != NULL) {
-        slots[index++] = unit;
-        unit = strtok_r(NULL, delimiter, &context);
+  int index = 0;
+  char *unit = strtok_r(text, delimiter, &context);
+  while (unit != NULL) {
+    slots[index++] = unit;
+    unit = strtok_r(NULL, delimiter, &context);
+  }
+  return index;
+}
+
+bool find_in_string(char *string, char symbol) {
+  char *c;
+  for (c = string; *c != '\0'; c++) {
+    if (*c == symbol) {
+      return true;
     }
-    return index;
+  }
+  return false;
 }
 
-bool FindInString(char *string, char symbol) {
-    char *c;
-    for (c = string; *c != '\0'; c++) {
-        if (*c == symbol) {
-            return true;
-        }
+int is_number(char *string) {
+  char *c;
+  for (c = string; *c != '\0'; c++) {
+    if (!isdigit((int)*c)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool is_empty(char *string) { return string == NULL || string[0] == '\0'; }
+
+bool legal_config_name(char *string) {
+  char *c;
+  for (c = string; *c != '\0'; c++) {
+    if (islower((int)*c) || *c == ' ') {
+      continue;
     }
     return false;
+  }
+  return true;
 }
 
-int IsNumber(char *string) {
-    char *c;
-    for (c = string; *c != '\0'; c++) {
-        if (!isdigit((int)*c)) {
-            return false;
-        }
+IR *parse(Context *c, IR *ir, char *code) {
+  // Definer delimitere
+  char newline[] = "\n";
+  char commentDelim[] = "!";
+  char configNameDelim[] = ":";
+  char branchDelim[] = ";";
+  char inBranchDelim[] = "|";
+  char operationDelim[] = ",";
+
+  char *lines[MAX_CONF_COUNT] = {0};
+  int lineCount = split_on(lines, code, newline);
+  assert(lineCount < MAX_CONF_COUNT);
+
+  IConfig *conf = NULL;
+
+  int branchIndex = 0;
+  for (int currentLine = 0; currentLine < lineCount; ++currentLine) {
+    char *lineContext = lines[currentLine];
+
+    // Skip the line if it is a comment
+    if (*lineContext == COMMENT_CHAR) {
+      continue;
     }
-    return true;
-}
-
-bool isEmpty(char *string) {
-    return string == NULL || string[0] == '\0';
-}
-
-bool legalConfigName(char *string) {
-    char *c;
-    for (c = string; *c != '\0'; c++) {
-        if (islower((int)*c) || *c == ' ') {
-            continue;
-        }
-        return false;
-    }
-    return true;
-}
-
-Machine Parse(Context *c, char *code) {
-    Machine m = {0};
-    for (int i = 0; i < TAPE_LENGTH; i++) {
-        m.tape[i] = ' ';
+    if (*trim(lineContext) == '\0') {
+      continue;
     }
 
-    ConfigDefHelper configs[CONFIGURATION_COUNT] = {0};
+    // Determine whether or not this line is the declaration of a new
+    // configuration. If it is, create the new configuration in the
+    // machine struct and change 'c' to refer to it.
+    if (find_in_string(lineContext, ':')) {
+      char *name = strtok_r(NULL, configNameDelim, &lineContext);
+      name = trim(name);
+      if (is_empty(lineContext) && !name) {
+        error(c, "missing configuration name", currentLine);
+        lineContext = name;
+      };
 
-    // Definer delimitere
-    char newline[] = "\n";
-    char commentDelim[] = "!";
-    char configNameDelim[] = ":";
-    char branchDelim[] = ";";
-    char inBranchDelim[] = "|";
-    char operationDelim[] = ",";
+      if (!legal_config_name(name)) {
+        error(c, "configuration name must be all lower case", currentLine);
+      }
 
-    char codeToParse[2048];
-    // TODO test for bad size
-    strcpy(codeToParse, code);
+      int prevIndex = find_config(ir->configs, name);
+      if (ir->configs[prevIndex].defined) {
+        error(c, "redefinition of configuration", currentLine);
+      }
 
-    char *lines[CONFIGURATION_LENGTH] = {0};
-    int lineCount = splitOn(lines, codeToParse, newline);
+      int configIndex = insert_config(ir->configs, name);
 
-    Configuration *conf = NULL;
-    int branchIndex = 0;
-    for (int lineIndex = 0; lineIndex < lineCount; ++lineIndex) {
-        char currentLine[256];
-        // TODO test for bad size
-        strcpy(currentLine, lines[lineIndex]);
+      // We have found a n actual declaration of the
+      // configuration, so we set it to defined.
+      // This does not mean that the definition
+      // is valid, only that it is not referenced
+      // by a different configuration without
+      // being defined.
+      ir->configs[configIndex].defined = true;
+      conf = &ir->configs[configIndex];
 
-        // Skip the line if it is a comment
-        if (*currentLine == COMMENT_CHAR) {
-            continue;
-        }
-        if (*trim(currentLine) == 0) {
-            continue;
-        }
+      conf->name = name;
+      conf->definedOn = currentLine;
 
-        // Determine whether or not this line is the declaration of a new
-        // configuration. If it is, create the new configuration in the
-        // machine struct and change 'c' to refer to it.
-        char *lineContext = currentLine;
-        if (FindInString(lines[lineIndex], ':')) {
-            // Tokeniser de ulike dele av branchen
-            // TODO test for bad size
-            char *name = strtok_r(NULL, configNameDelim, &lineContext);
-            name = trim(name);
-            if(isEmpty(lineContext) && !name) {
-                error(c, "missing configuration name", lineIndex);
-                lineContext = name;
-            };
+      // Reset branch index since we are in a new configuration
+      branchIndex = 0;
+    }
+    if (conf == NULL) {
+      error(c, "missing configuration name (declare like 'begin: ...'",
+            currentLine);
+      continue;
+    }
+    if (is_empty(lineContext)) {
+      error(c, "configuration is missing parameters", currentLine);
+      continue;
+    }
 
-            if(!legalConfigName(name)) {
-                error(c, "configuration name must be all lower case", lineIndex);
-            }
+    // Increment branch index for next pass
+    IBranch *branch = &conf->branches[branchIndex];
+    branch->definedOn = currentLine;
 
-            int prevIndex = findConfig(configs, name);
-            if (configs[prevIndex].defined) {
-                error(c, "redefinition of configuration", lineIndex);
-            }
+    char *symbol = strtok_r(NULL, inBranchDelim, &lineContext);
+    symbol = trim(symbol);
+    branch->matchSymbol = symbol;
 
-            int configurationIndex = insertConfig(configs, name);
-            configs[configurationIndex].defined = true;
-            conf = &m.configurations[configurationIndex];
+    for (int i = 0; i < branchIndex; i++) {
+      if (strcmp(conf->branches[i].matchSymbol, symbol) == 0) {
+        error(c, "branch for given symbol is already defined", currentLine);
+      }
+    }
+    branchIndex++;
 
-            // TODO test for bad size
-            strcpy(conf->name, name);
+    if (is_empty(symbol)) {
+      error(c, "branch is missing match symbol (first parameter)", currentLine);
+    };
 
+    char *opsString = strtok_r(NULL, inBranchDelim, &lineContext);
+    opsString = trim(opsString);
+    // TODO set ops for a branch..
+    // strcpy(branch->ops, opsString);
 
-            // Reset branch index since we are in a new configuration
-            branchIndex = 0;
-        }
-        if (conf == NULL) {
-            error(c, "missing configuration name (declare like 'begin: ...'", lineIndex);
-            continue;
-        }
-        if (isEmpty(lineContext)) {
-            error(c, "configuration is missing parameters", lineIndex);
-            continue;
-        }
+    char *nextName = strtok_r(NULL, inBranchDelim, &lineContext);
+    nextName = trim(nextName);
 
-        // Increment branch index for next pass
-        Branch *b = &conf->branch[branchIndex];
+    bool hasNext = true;
+    if (is_empty(nextName)) {
+      error(c, "branch is missing next configuration (last parameter)",
+            currentLine);
+      hasNext = false;
+    };
 
-        // At this point, what is left in lineContext is
-        // the information of the branch on the line
-        //char *branchInfo = lineContext;
+    if (hasNext) {
+      int nextConfigIndex = find_config(ir->configs, nextName);
+      if (nextConfigIndex == NOT_DEFINED) {
+        nextConfigIndex = insert_config(ir->configs, nextName);
+        ir->configs[nextConfigIndex].definedOn = currentLine;
+      }
 
-        // Copy the branch information into the branch, for
-        // printing purposes..
-        // TODO test for bad size
+      branch->next = &ir->configs[nextConfigIndex];
+    }
 
-        char *symbol = strtok_r(NULL, inBranchDelim, &lineContext);
-        symbol = trim(symbol);
-        strcpy(b->symbol, symbol);
+    // TODO TODO TODO this is the translation to bytecode, must be done later
+    /*
+    if (strcmp(symbol, "none") == 0) {
+      branch->matchSymbol = NONE;
+    } else if (strcmp(symbol, "else") == 0) {
+      branch->matchSymbol = ELSE;
+    } else {
+      branch->matchSymbol = *symbol;
+    }
 
-        for(int i = 0; i < branchIndex; i++) {
-            if(strcmp(conf->branch[i].symbol, symbol) == 0) {
-                error(c, "branch for given symbol is already defined", lineIndex);
-            }
-        }
-        branchIndex++;
+    // TODO Error handling during this parsing...
+    // TODO Parameter is no longer varParameter, but
+    // parameter.num or parameter.string
+    // TODO Also handle bool op.isnum
+    char *ops[MAX_OPERATION_COUNT] = {0};
+    int opCount = splitOn(ops, opsString, operationDelim);
 
-        if(isEmpty(symbol)) { error(c, "branch is missing match symbol (first parameter)", lineIndex); };
-
-        char *opsString = strtok_r(NULL, inBranchDelim, &lineContext);
-        opsString = trim(opsString);
-        strcpy(b->ops, opsString);
-
-        char *next = strtok_r(NULL, inBranchDelim, &lineContext);
-        next = trim(next);
-        strcpy(b->next, next);
-
-        bool noNext = false;
-        if(isEmpty(next)) {
-            error(c, "branch is missing next configuration (last parameter)", lineIndex);
-            noNext = true;
-        };
-
-
-        // Avgjør hva match-symbol skal vare, ta hensyn til definerte variabler
-        if (strcmp(symbol, "none") == 0) {
-            b->matchSymbol = NONE;
-        } else if (strcmp(symbol, "else") == 0) {
-            b->matchSymbol = ELSE;
+    for (int i = 0; i < opCount; ++i) {
+      char *op = trim(ops[i]);
+      if (*op == 'N') {
+        b->operations[i].op = N;
+      } else if (*op == 'P') {
+        b->operations[i].op = P;
+        strcpy(b->operations[i].varParameter, (op + 1));
+      } else if (*op == 'E') {
+        b->operations[i].op = E;
+      } else if (*op == 'R') {
+        b->operations[i].op = R;
+        // TODO assert that param is a number
+        char param = *(op + 1);
+        if (param == ',' || param == 0) {
+          b->operations[i].parameter = 1;
         } else {
-            b->matchSymbol = *symbol;
+          b->operations[i].parameter = param - 48;
         }
-
-        char *ops[MAX_OPERATION_COUNT] = {0};
-        int opCount = splitOn(ops, opsString, operationDelim);
-
-        for (int i = 0; i < opCount; ++i) {
-            char *op = trim(ops[i]);
-            if (*op == 'N') {
-                b->operations[i].op = N;
-            } else if (*op == 'P') {
-                b->operations[i].op = P;
-                strcpy(b->operations[i].varParameter, (op + 1));
-            } else if (*op == 'E') {
-                b->operations[i].op = E;
-            } else if (*op == 'R') {
-                b->operations[i].op = R;
-                // TODO assert that param is a number
-                char param = *(op + 1);
-                if (param == ',' || param == 0) {
-                    b->operations[i].parameter = 1;
-                } else {
-                    b->operations[i].parameter = param - 48;
-                }
-            } else if (*op == 'L') {
-                b->operations[i].op = L;
-                // TODO assert that param is a number
-                char param = *(op + 1);
-                if (param == ',' || param == 0) {
-                    b->operations[i].parameter = 1;
-                } else {
-                    b->operations[i].parameter = param - 48;
-                }
-            }
+      } else if (*op == 'L') {
+        b->operations[i].op = L;
+        // TODO assert that param is a number
+        char param = *(op + 1);
+        if (param == ',' || param == 0) {
+          b->operations[i].parameter = 1;
+        } else {
+          b->operations[i].parameter = param - 48;
         }
-
-        // Sett inn index til neste konfigurasjon
-        if(noNext) { continue; }
-        int index = insertConfig(configs, next);
-        assert(index < 0xff);
-        b->nextConfiguration = (uint8_t)index;
+      } else {
+        // TODO Error: invalid function name.
+      }
     }
-    return m;
+    */
+  }
+  // Iterate over branches of configs and gooo
+  /* TODO TODO TODO
+  for (int ci = 0; ci < MAX_CONF_COUNT; ci++) {
+    char name = ir.configs[ci].name[0];
+    bool defined = ir.configs[ci].defined;
+    if (name && !defined) {
+      error(c, "a configuration is not properly defined", 0);
+    }
+  }
+  */
+
+  /*
+  // TODO actually make the bytecode.
+  Machine m = {0};
+  for (int i = 0; i < TAPE_LENGTH; i++) {
+    m.tape[i] = ' ';
+  }
+  return m;
+  */
+  // TODO handle_errors(c);
+  return ir;
 }
 
-void Right(Machine *m, int count) {
-    assert(m->pointer != TAPE_LENGTH);
-    assert(count > 0 && count < (TAPE_LENGTH - m->pointer));
-    m->pointer += count;
+void right(Machine *m, int count) {
+  assert(m->pointer != TAPE_LENGTH);
+  assert(count > 0 && count < (TAPE_LENGTH - m->pointer));
+  m->pointer += count;
 }
 
-void Left(Machine *m, int count) {
-    assert(m->pointer != 0);
-    // TODO fix den under
-    // assert(count > 0 && (TAPE_LENGTH - m->pointer) > count);
-    m->pointer -= count;
+void left(Machine *m, int count) {
+  assert(m->pointer != 0);
+  // TODO fix den under
+  // assert(count > 0 && (TAPE_LENGTH - m->pointer) > count);
+  m->pointer -= count;
 }
 // The operations the machine can perform on the tape.
-void Print(Machine *m, char *sym) {
-    assert(strlen(sym) > 0);
-    if(strlen(sym) > 1) {
-        while(*sym != 0) {
-            m->tape[m->pointer] = *sym++;
-            Right(m, 2);
-        }
-    } else {
-        m->tape[m->pointer] = *sym;
+void print(Machine *m, char *sym) {
+  assert(strlen(sym) > 0);
+  if (strlen(sym) > 1) {
+    while (*sym != 0) {
+      m->tape[m->pointer] = *sym++;
+      right(m, 2);
     }
+  } else {
+    m->tape[m->pointer] = *sym;
+  }
 }
 
-void Erase(Machine *m) { m->tape[m->pointer] = 0; }
+void erase(Machine *m) { m->tape[m->pointer] = 0; }
 
-char Read(Machine *m) { return m->tape[m->pointer]; }
+char read(Machine *m) { return m->tape[m->pointer]; }
 
-void CopyN(size_t SourceACount, char *SourceA, size_t DestCount, char *Dest) {
-    for (int Index = 0; Index < SourceACount; ++Index) {
-        *Dest++ = *SourceA++;
-    }
-    *Dest++ = 0;
+void copy_n(size_t SourceACount, char *SourceA, size_t DestCount, char *Dest) {
+  for (int Index = 0; Index < SourceACount; ++Index) {
+    *Dest++ = *SourceA++;
+  }
+  *Dest++ = 0;
 }
 
-void PrintMachine(Machine *m, int topPointerAccessed, int lowerBound, int upperBound, bool verbose) {
+/*
+void PrintMachine(Machine *m, int topPointerAccessed, int lowerBound,
+                  int upperBound, bool verbose) {
+  char outputBuffer[TAPE_LENGTH];  // Buffer used for printing
+  char pointerBuffer[TAPE_LENGTH];
 
-    char outputBuffer[TAPE_LENGTH];  // Buffer used for printing
-    char pointerBuffer[TAPE_LENGTH];
+  int pointer = (m->pointer == 0) ? 1 : m->pointer;
 
-    int pointer = (m->pointer == 0) ? 1 : m->pointer;
+  for (int i = 0; i <= pointer; i++) {
+    pointerBuffer[i] = ' ';
+  }
 
-    for (int i = 0; i <= pointer ; i++) {
-        pointerBuffer[i] = ' ';
+  // On the first pass the pointer will be set to 0, but
+  // we want it to point on a blank space in the tape
+  strcpy(outputBuffer, m->tape);
+  outputBuffer[topPointerAccessed + 1] = '\0';
+
+  pointerBuffer[pointer - lowerBound + 1] = 'v';
+  pointerBuffer[pointer - lowerBound + 2] = '\0';
+
+  // TODO test for bad size
+  if (lowerBound != -1 || upperBound != -1) {
+    char boundBuffer[WINDOWSIZE + 1];
+    outputBuffer[upperBound] = 0;
+    strcpy(boundBuffer, outputBuffer + lowerBound);
+    strcpy(outputBuffer, boundBuffer);
+
+    outputBuffer[lowerBound + upperBound] = '\0';
+  }
+
+  if (verbose) {
+    Configuration *c = &m->configurations[m->configuration];
+    Branch *b = &c->branch[m->branch];
+
+    char leftLimit = '[';
+    char rightLimit = ']';
+    if (upperBound < topPointerAccessed) {
+      rightLimit = '>';
+    }
+    if (lowerBound > 0) {
+      leftLimit = '<';
     }
 
-    // On the first pass the pointer will be set to 0, but
-    // we want it to point on a blank space in the tape
-    strcpy(outputBuffer,  m->tape);
-    outputBuffer[topPointerAccessed + 1] = '\0';
+    printf("> %s:%s | %s | %s\n%s\n%c%s%c\n\n\n", c->name, b->symbol, b->ops,
+           b->next, pointerBuffer, leftLimit, outputBuffer, rightLimit);
+  } else {
+    printf("%s \n[%s]\n\n", pointerBuffer, outputBuffer);
+  }
+}
+*/
 
-    pointerBuffer[pointer - lowerBound + 1] = 'v';
-    pointerBuffer[pointer - lowerBound + 2] = '\0';
+void run_machine(Context *context, Machine *m, int iterations, char *result, bool verbose) {
+  int topPointerAccessed = 1;  // Value used for determining how much to print
 
-    // TODO test for bad size
-    if ( lowerBound != -1 || upperBound != -1 ) {
-        char boundBuffer[WINDOWSIZE + 1];
-        outputBuffer[upperBound] = 0;
-        strcpy(boundBuffer,  outputBuffer+lowerBound);
-        strcpy(outputBuffer, boundBuffer);
+  int window = 48;
+  int highBound = window;
+  int lowBound = 0;
 
-        outputBuffer[lowerBound+upperBound] = '\0';
-    }
+  while (iterations-- > 0) {
+    assert(m->pointer <= TAPE_LENGTH);
 
-    if(verbose) {
-        Configuration *c = &m->configurations[m->configuration];
-        Branch *b = &c->branch[m->branch];
+    Configuration c = m->configurations[m->configuration];
+    for (int branchIndex = 0; branchIndex < MAX_BRANCH_COUNT; branchIndex++) {
+      char symbol = m->tape[m->pointer];
+      Branch branch = c.branch[branchIndex];
 
-        char leftLimit = '[';
-        char rightLimit = ']';
-        if(upperBound < topPointerAccessed) {
-            rightLimit = '>';
+      // Here we are checking whether or not we are in the correct branch
+      // if we are not, we will go on to the next iteration.
+      // If we are, we will execute the branch and move on to the next
+      // configuration
+      if (branch.matchSymbol != ELSE && branch.matchSymbol != symbol) {
+        continue;
+      }
+      // For printing purposes
+      m->branch = branchIndex;
+
+      // Execute all operations in branch until a N
+      bool nop = false;
+      for (int operationIndex = 0; operationIndex < MAX_OPERATION_COUNT;
+           ++operationIndex) {
+        Operation operation = branch.operations[operationIndex];
+        switch (operation.op) {
+          case N: {
+            nop = true;
+          } break;
+          case P: {
+            print(m, operation.parameter.string);
+          } break;
+          case E: {
+            erase(m);
+          } break;
+          case R: {
+            right(m, operation.parameter.number);
+          } break;
+          case L: {
+            left(m, operation.parameter.number);
+          } break;
         }
-        if(lowerBound > 0) {
-            leftLimit = '<';
+        if (nop) {
+          break;
         }
+      }
 
-        printf("> %s:%s | %s | %s\n%s\n%c%s%c\n\n\n", c->name, b->symbol, b->ops, b->next, pointerBuffer, leftLimit, outputBuffer, rightLimit);
-    } else {
-        printf("%s \n[%s]\n\n", pointerBuffer, outputBuffer);
+      // Change topPointerAccessed if we have
+      // touched a higher pointer.
+      // This is for printing purposes.
+      if (m->pointer > topPointerAccessed) {
+        topPointerAccessed = m->pointer;
+      }
+      // Adjust the window of the tape to print
+      // if we move out of the defined boundaries
+      if (m->pointer >= highBound || m->pointer <= lowBound) {
+        if (topPointerAccessed - m->pointer >= window / 2) {
+          printf("more");
+          highBound = m->pointer + window / 2;
+          lowBound = m->pointer - window / 2;
+        } else {
+          highBound = topPointerAccessed + 1;
+          lowBound = highBound - window;
+        }
+      }
+
+      if (verbose) {
+        // PrintMachine(m, topPointerAccessed, lowBound, highBound, true);
+      }
+      m->configuration = branch.nextConfiguration;
+      break;
     }
+  }
+
+  // Here we want to print the result of the computation
+  // into a buffer for printing.
+  // We do this by writing every second value from the turing
+  // machine's tape into the result buffer (following turing's
+  // conventions).
+
+  int maxIndex = 2 * (int)floor(topPointerAccessed / 2) + 2;
+  int resultIndex = 0;
+  for (int tapeIndex = 0; tapeIndex < maxIndex; tapeIndex += 2) {
+    result[resultIndex++] = m->tape[tapeIndex];
+  }
 }
 
-
-
-void RunMachine(Machine *m, int iterations, char *result, bool verbose) {
-    int topPointerAccessed = 1;  // Value used for determining how much to print
-
-    int window = 48;
-    int highBound = window;
-    int lowBound = 0;
-
-    while (iterations-- > 0) {
-        assert(m->pointer <= TAPE_LENGTH);
-
-        Configuration c = m->configurations[m->configuration];
-        for (int branchIndex = 0; branchIndex < MAX_BRANCH_COUNT; branchIndex++) {
-            char symbol = m->tape[m->pointer];
-            Branch branch = c.branch[branchIndex];
-
-            // Here we are checking whether or not we are in the correct branch
-            // if we are not, we will go on to the next iteration.
-            // If we are, we will execute the branch and move on to the next
-            // configuration
-            if (branch.matchSymbol != ELSE && branch.matchSymbol != symbol) {
-                continue;
-            }
-            // For printing purposes
-            m->branch = branchIndex;
-
-            // Execute all operations in branch until a N
-            bool nop = false;
-            for (int operationIndex = 0; operationIndex < MAX_OPERATION_COUNT;
-                    ++operationIndex) {
-                Operation operation = branch.operations[operationIndex];
-                switch (operation.op) {
-                    case N: {
-                                nop = true;
-                            } break;
-                    case P: {
-                                Print(m, operation.varParameter);
-                            } break;
-                    case E: {
-                                Erase(m);
-                            } break;
-                    case R: {
-                                Right(m, operation.parameter);
-                            } break;
-                    case L: {
-                                Left(m, operation.parameter);
-                            } break;
-                }
-                if (nop) {
-                    break;
-                }
-            }
-
-            // Change topPointerAccessed if we have
-            // touched a higher pointer.
-            // This is for printing purposes.
-            if (m->pointer > topPointerAccessed) {
-                topPointerAccessed = m->pointer;
-            }
-            // Adjust the window of the tape to print
-            // if we move out of the defined boundaries
-            if ( m->pointer >= highBound || m->pointer <= lowBound) {
-                if (topPointerAccessed - m->pointer >= window/2) {
-                    printf("more");
-                    highBound = m->pointer + window/2 ;
-                    lowBound  = m->pointer - window/2 ;
-                } else {
-                    highBound = topPointerAccessed + 1;
-                    lowBound = highBound - window ;
-                }
-            }
-
-            if(verbose) {
-                PrintMachine(m, topPointerAccessed, lowBound, highBound, true);
-            }
-            m->configuration = branch.nextConfiguration;
-            break;
-        }
-    }
-
-    // Here we want to print the result of the computation
-    // into a buffer for printing.
-    // We do this by writing every second value from the turing
-    // machine's tape into the result buffer (following turing's
-    // conventions).
-
-    int maxIndex = 2*(int)floor(topPointerAccessed/2) + 2;
-    int resultIndex = 0;
-    for(int tapeIndex = 0; tapeIndex < maxIndex; tapeIndex += 2) {
-        result[resultIndex++] = m->tape[tapeIndex];
-    }
-
+Machine translate(IR ir) {
+  /*
+   * Iterer over konfigurasjoner i ir.configs
+   * For hver, legg til alle branches i ir.configs[i].branches
+   * For hver branch, legg til alle operasjoner.
+   * Legg til 'next' sin indeks ved find(ir.configs[i].next.name);
+   *
+   */
+  Machine m;
+  return m;
 }
 
 int main(int argc, char *argv[]) {
+  Context c = {0};
 
-    Context c = {0};
+  int timesToRun = -1;
+  char *filename = 0;
+  bool verbose = false;
 
-    int timesToRun = -1;
-    char *filename = 0;
-    bool verbose = false;
+  for (int i = 1; i < argc; ++i) {
+    if (is_number(argv[i])) {
+      char *endPtr;
+      timesToRun = strtol(argv[i], &endPtr, 10);
+    } else if (*argv[i] == '-') {
+      if (*(argv[i] + 1) == 'v') {
+        verbose = true;
+      }
 
-    for (int i = 1; i < argc; ++i) {
-        if (IsNumber(argv[i])) {
-            char *endPtr;
-            timesToRun = strtol(argv[i], &endPtr, 10);
-        } else if (*argv[i] == '-') {
-            if (*(argv[i] + 1) == 'v') {
-                verbose = true;
-            }
-
-        } else if (!filename) {
-            filename = argv[i];
-        }
+    } else if (!filename) {
+      filename = argv[i];
     }
+  }
 
-    if (filename == 0) {
-        error(&c, "no filename specified", FILE_ERROR);
-    }
+  if (filename == 0) {
+    error(&c, "no filename specified", FILE_ERROR);
+  }
 
-    if (timesToRun == -1) {
-        error(&c, "please specify number of passes to make", FILE_ERROR);
-    }
+  if (timesToRun == -1) {
+    error(&c, "please specify number of passes to make", FILE_ERROR);
+  }
 
-    char result[256] = {0};
+//  char result[256] = {0};
 
+  char *bytecode = read_source(&c, filename);
 
-    char *bytecode = ReadSource(&c, filename);
-    Machine m = Parse(&c, bytecode);
-    if(c.error) {
-        handleErrors(&c);
-    }
+  IR ir = {0}; //(IR *)malloc(sizeof(IR));
 
-    RunMachine(&m, timesToRun, result, verbose);
+  parse(&c, &ir, bytecode);
+  // Machine m = translate(ir);
+/*  run_machine(&c, &m, timesToRun, result, verbose);
 
-    char stringResult[256];
-    ParseBinaryString(stringResult, result);
+   char stringResult[256];
+  parse_string(stringResult, result);
 
-    float floatResult = ParseBinaryPointValue(result);
+  float floatResult = parse_binary_point_value(result);
 
-    // Print interpretations of the result
-    printf("\nBinary:\t%s\nString:\t%s\nFloat:\t%f\n", result, stringResult, floatResult);
+  // Print interpretations of the result
+  printf("\nBinary:\t%s\nString:\t%s\nFloat:\t%f\n", result, stringResult,
+         floatResult);
+         */
 
-
-    return 0;
+  return 0;
 }

--- a/alan.c
+++ b/alan.c
@@ -59,32 +59,30 @@
 typedef enum Op { N = 0, P, E, R, L } Op;
 
 typedef struct Operation {
-    Op name;
-    union {
-        char *string;
-        int number;
-    };
+  Op name;
+  union {
+    char *string;
+    int number;
+  };
 } Operation;
 
 typedef struct Branch {
-    char matchSymbol;
-    int nextConfiguration;
-    IBranch *info;
-    Operation ops[MAX_OPERATION_COUNT];
+  char matchSymbol;
+  int nextConfiguration;
+  IBranch *info;
+  Operation ops[MAX_OPERATION_COUNT];
 } Branch;
 
 typedef struct Configuration {
-    IConfig *info;
-    Branch branches[MAX_BRANCH_COUNT];
+  IConfig *info;
+  Branch branches[MAX_BRANCH_COUNT];
 } Configuration;
 
 typedef struct Machine {
-    int pointer;
-    char tape[TAPE_LENGTH];
+  int pointer;
+  char tape[TAPE_LENGTH];
 
-    int configuration;
-    int branch;
-    Configuration configurations[MAX_CONF_COUNT];
+  Configuration configurations[MAX_CONF_COUNT];
 
 } Machine;
 
@@ -94,489 +92,488 @@ typedef struct Machine {
  * and allows us to print detailed information at runtime.
  */
 typedef struct IOperation {
-    char name;
-    bool isNum;
-    union {
-        char *string;
-        int number;
-    };
+  char name;
+  bool isNum;
+  union {
+    char *string;
+    int number;
+  };
 } IOperation;
 
 typedef struct IBranch {
-    int definedOn;
-    char *matchSymbol;
-    IConfig *next;
-    int opCount;
-    char *opsString;
-    IOperation ops[MAX_OPERATION_COUNT];
+  int definedOn;
+  char *matchSymbol;
+  IConfig *next;
+  int opCount;
+  char *opsString;
+  IOperation ops[MAX_OPERATION_COUNT];
 } IBranch;
 
 typedef struct IConfig {
-    int definedOn;
-    bool defined;
-    char *name;
-    int branchCount;
-    IBranch branches[MAX_BRANCH_COUNT];
+  int definedOn;
+  bool defined;
+  char *name;
+  int branchCount;
+  IBranch branches[MAX_BRANCH_COUNT];
 } IConfig;
 
 typedef struct IR {
-    int configCount;
-    IConfig configs[MAX_CONF_COUNT];
+  int configCount;
+  IConfig configs[MAX_CONF_COUNT];
 } IR;
 
 typedef struct Error {
-    char *message;
-    int line;
+  char *message;
+  int line;
 } Error;
 
 typedef struct Context {
-    IR parseInfo;
+  IR parseInfo;
 
-    bool error;
-    bool errorOverflow;
-    int nextError;
-    Error errors[MAX_ERROR];
+  bool error;
+  bool errorOverflow;
+  int nextError;
+  Error errors[MAX_ERROR];
 } Context;
 
 char *trim(char *str) {
-    // TODO Write a simpler version of this
-    // https://stackoverflow.com/questions/122616/how-do-i-trim-leading-trailing-whitespace-in-a-standard-way
-    size_t len = 0;
-    char *frontp = str;
-    char *endp = NULL;
+  // TODO Write a simpler version of this
+  // https://stackoverflow.com/questions/122616/how-do-i-trim-leading-trailing-whitespace-in-a-standard-way
+  size_t len = 0;
+  char *frontp = str;
+  char *endp = NULL;
 
-    if (str == NULL) {
-        return NULL;
-    }
-    if (str[0] == '\0') {
-        return str;
-    }
-
-    len = strlen(str);
-    endp = str + len;
-
-    /* Move the front and back pointers to address the first non-whitespace
-     * characters from each end.
-     */
-    while (isspace((unsigned char)*frontp)) {
-        ++frontp;
-    }
-    if (endp != frontp) {
-        while (isspace((unsigned char)*(--endp)) && endp != frontp) {
-        }
-    }
-
-    if (frontp != str && endp == frontp)
-        *str = '\0';
-    else if (str + len - 1 != endp)
-        *(endp + 1) = '\0';
-
-    /* Shift the string so that it starts at str so that if it's dynamically
-     * allocated, we can still free it on the returned pointer.  Note the reuse
-     * of endp to mean the front of the string buffer now.
-     */
-    endp = str;
-    if (frontp != str) {
-        while (*frontp) {
-            *endp++ = *frontp++;
-        }
-        *endp = '\0';
-    }
-
+  if (str == NULL) {
+    return NULL;
+  }
+  if (str[0] == '\0') {
     return str;
+  }
+
+  len = strlen(str);
+  endp = str + len;
+
+  /* Move the front and back pointers to address the first non-whitespace
+   * characters from each end.
+   */
+  while (isspace((unsigned char)*frontp)) {
+    ++frontp;
+  }
+  if (endp != frontp) {
+    while (isspace((unsigned char)*(--endp)) && endp != frontp) {
+    }
+  }
+
+  if (frontp != str && endp == frontp)
+    *str = '\0';
+  else if (str + len - 1 != endp)
+    *(endp + 1) = '\0';
+
+  /* Shift the string so that it starts at str so that if it's dynamically
+   * allocated, we can still free it on the returned pointer.  Note the reuse
+   * of endp to mean the front of the string buffer now.
+   */
+  endp = str;
+  if (frontp != str) {
+    while (*frontp) {
+      *endp++ = *frontp++;
+    }
+    *endp = '\0';
+  }
+
+  return str;
 }
 
 void code_error(Context *c, char *msg, int line) {
-    c->error = true;
-    if (c->nextError < MAX_ERROR) {
-        // TODO bound check and assert
-        c->errors[c->nextError].message = msg;
-        c->errors[c->nextError].line = line;
-        c->nextError++;
-    } else {
-        c->errorOverflow = true;
-    }
+  c->error = true;
+  if (c->nextError < MAX_ERROR) {
+    // TODO bound check and assert
+    c->errors[c->nextError].message = msg;
+    c->errors[c->nextError].line = line;
+    c->nextError++;
+  } else {
+    c->errorOverflow = true;
+  }
 }
 
 void error(Context *c, char *msg, int line) {
-    c->error = true;
-    if (c->nextError < MAX_ERROR) {
-        // TODO bound check and assert
-        c->errors[c->nextError].message = msg;
-        c->errors[c->nextError].line = line;
-        c->nextError++;
-    } else {
-        c->errorOverflow = true;
-    }
+  c->error = true;
+  if (c->nextError < MAX_ERROR) {
+    // TODO bound check and assert
+    c->errors[c->nextError].message = msg;
+    c->errors[c->nextError].line = line;
+    c->nextError++;
+  } else {
+    c->errorOverflow = true;
+  }
 }
 
 void warning(Context *c, char *msg, int line) {
-    if (c->nextError < MAX_ERROR) {
-        // TODO bound check and assert
-        c->errors[c->nextError].message = msg;
-        c->errors[c->nextError].line = line;
-        c->nextError++;
-    } else {
-        c->errorOverflow = true;
-    }
+  if (c->nextError < MAX_ERROR) {
+    // TODO bound check and assert
+    c->errors[c->nextError].message = msg;
+    c->errors[c->nextError].line = line;
+    c->nextError++;
+  } else {
+    c->errorOverflow = true;
+  }
 }
 
 void handle_errors(Context *c) {
-    for (int i = 0; i < c->nextError; i++) {
-        int line = c->errors[i].line;
-        char *msg = c->errors[i].message;
-        if (line == FILE_ERROR) {
-            fprintf(stderr, "\n\tFile error:\n\t  %s\n", msg);
-        } else if (line == ARGUMENT_ERROR) {
-            fprintf(stderr, "\n\tArgument error:\n\t  %s\n", msg);
-        } else {
-            fprintf(stderr, "\n\tError in line %i:\n\t  %s\n", ++line, msg);
-        }
+  for (int i = 0; i < c->nextError; i++) {
+    int line = c->errors[i].line;
+    char *msg = c->errors[i].message;
+    if (line == FILE_ERROR) {
+      fprintf(stderr, "\n\tFile error:\n\t  %s\n", msg);
+    } else if (line == ARGUMENT_ERROR) {
+      fprintf(stderr, "\n\tArgument error:\n\t  %s\n", msg);
+    } else {
+      fprintf(stderr, "\n\tError in line %i:\n\t  %s\n", ++line, msg);
     }
-    if (c->error) {
-        exit(EXIT_FAILURE);
-    }
+  }
+  if (c->error) {
+    exit(EXIT_FAILURE);
+  }
 }
 
 char *read_source(Context *c, char *filename) {
-    // https://www.tutorialspoint.com/cprogramming/c_file_io.htm
-    FILE *file =
-        fopen(filename, "rb");  // TODO Might be problematic outside of windows
-    if (!file) {
-        error(c, "File could not be loaded. Does it exist?", FILE_ERROR);
-        return 0;
-    };
-    fseek(file, 0, SEEK_END);
-    long fsize = ftell(file);
-    fseek(file, 0, SEEK_SET);
+  // https://www.tutorialspoint.com/cprogramming/c_file_io.htm
+  FILE *file =
+      fopen(filename, "rb");  // TODO Might be problematic outside of windows
+  if (!file) {
+    error(c, "File could not be loaded. Does it exist?", FILE_ERROR);
+    return 0;
+  };
+  fseek(file, 0, SEEK_END);
+  long fsize = ftell(file);
+  fseek(file, 0, SEEK_SET);
 
-    char *bytecode = (char *)malloc(fsize + 1);
-    fread(bytecode, fsize, 1, file);
-    fclose(file);
-    bytecode[fsize] = 0;  // Add line-terminator
+  char *bytecode = (char *)malloc(fsize + 1);
+  fread(bytecode, fsize, 1, file);
+  fclose(file);
+  bytecode[fsize] = 0;  // Add line-terminator
 
-    return bytecode;
+  return bytecode;
 }
 
 float parse_binary_point_value(char *numstring) {
-    float sum = 0;
-    char *c = numstring;
-    float n = 1;
+  float sum = 0;
+  char *c = numstring;
+  float n = 1;
 
-    while (*c != '\0') {
-        float i = (float)(*c++ - 48);
-        sum += i * 1.0f / powf(2.0f, n);
-        n *= 2;
-    }
+  while (*c != '\0') {
+    float i = (float)(*c++ - 48);
+    sum += i * 1.0f / powf(2.0f, n);
+    n *= 2;
+  }
 
-    return sum;
+  return sum;
 }
 
 char *parse_string(char *result, char *binary) {
-    char *c = binary;
-    int resultIndex = 0;
-    while (*c != 0) {
-        int n = 128;
-        char sum = 0;
-        for (int i = 0; i < 8; i++) {
-            if (*c == 0) {
-                break;
-            }
-            if (*c == '1') {
-                assert(n < 0xff);
-                sum += (char)n * 1;
-            }
-            n /= 2;
-            c++;
-        }
-        result[resultIndex++] = sum;
+  char *c = binary;
+  int resultIndex = 0;
+  while (*c != 0) {
+    int n = 128;
+    char sum = 0;
+    for (int i = 0; i < 8; i++) {
+      if (*c == 0) {
+        break;
+      }
+      if (*c == '1') {
+        assert(n < 0xff);
+        sum += (char)n * 1;
+      }
+      n /= 2;
+      c++;
     }
-    return result;
+    result[resultIndex++] = sum;
+  }
+  return result;
 }
 
 int insert_config(IConfig array[MAX_CONF_COUNT], char *str) {
-    for (int i = 0; i < MAX_CONF_COUNT; i++) {
-        if (array[i].name == NULL) {
-            // We have found an empty spot,
-            // which means the identifier is not in the list,
-            // so we put it here
-            // TODO handle bas size
-            array[i].name = str;
-            return i;
+  for (int i = 0; i < MAX_CONF_COUNT; i++) {
+    if (array[i].name == NULL) {
+      // We have found an empty spot,
+      // which means the identifier is not in the list,
+      // so we put it here
+      // TODO handle bas size
+      array[i].name = str;
+      return i;
 
-        } else if (strcmp(array[i].name, str) == 0) {
-            // The identifier already exists, so we return its return index
-            return i;
-        }
-        continue;
+    } else if (strcmp(array[i].name, str) == 0) {
+      // The identifier already exists, so we return its return index
+      return i;
     }
-    assert(false);
-    return -1;
+    continue;
+  }
+  assert(false);
+  return -1;
 }
 
 int find_config(IConfig array[MAX_CONF_COUNT], char *str) {
-    for (int i = 0; i < MAX_CONF_COUNT; i++) {
-        if (array[i].name == NULL) {
-            continue;
-        }
-        if (strcmp(array[i].name, str) == 0) {
-            // The identifier already exists, so we return its return index
-            return i;
-        }
-        continue;
+  for (int i = 0; i < MAX_CONF_COUNT; i++) {
+    if (array[i].name == NULL) {
+      continue;
     }
-    return -1;
+    if (strcmp(array[i].name, str) == 0) {
+      // The identifier already exists, so we return its return index
+      return i;
+    }
+    continue;
+  }
+  return -1;
 }
 
 int split_on(char *slots[], char *text, char *delimiter) {
-    char *context;
+  char *context;
 
-
-    int index = 0;
-    char *unit = strtok_r(text, delimiter, &context);
-    while (unit != NULL) {
-        slots[index++] = unit;
-        unit = strtok_r(NULL, delimiter, &context);
-    }
-    return index;
+  int index = 0;
+  char *unit = strtok_r(text, delimiter, &context);
+  while (unit != NULL) {
+    slots[index++] = unit;
+    unit = strtok_r(NULL, delimiter, &context);
+  }
+  return index;
 }
 
 bool find_in_string(char *string, char symbol) {
-    char *c;
-    for (c = string; *c != '\0'; c++) {
-        if (*c == symbol) {
-            return true;
-        }
+  char *c;
+  for (c = string; *c != '\0'; c++) {
+    if (*c == symbol) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 int is_number(char *string) {
-    char *c;
-    for (c = string; *c != '\0'; c++) {
-        if (!isdigit((int)*c)) {
-            return false;
-        }
+  char *c;
+  for (c = string; *c != '\0'; c++) {
+    if (!isdigit((int)*c)) {
+      return false;
     }
-    return true;
+  }
+  return true;
 }
 
 bool is_empty(char *string) { return string == NULL || string[0] == '\0'; }
 
 bool legal_config_name(char *string) {
-    char *c;
-    for (c = string; *c != '\0'; c++) {
-        if (islower((int)*c) || *c == ' ') {
-            continue;
-        }
-        return false;
+  char *c;
+  for (c = string; *c != '\0'; c++) {
+    if (islower((int)*c) || *c == ' ') {
+      continue;
     }
-    return true;
+    return false;
+  }
+  return true;
 }
 
 IR *parse(Context *c, IR *ir, char *code) {
-    // Definer delimitere
-    char newline[] = "\n";
-    char commentDelim[] = "!";
-    char configNameDelim[] = ":";
-    char branchDelim[] = ";";
-    char branchParamDelim[] = "|";
-    char operationDelim[] = ",";
+  // Definer delimitere
+  char newline[] = "\n";
+  char commentDelim[] = "!";
+  char configNameDelim[] = ":";
+  char branchDelim[] = ";";
+  char branchParamDelim[] = "|";
+  char operationDelim[] = ",";
 
-    char *lines[MAX_CONF_COUNT] = {0};
-    int lineCount = split_on(lines, code, newline);
-    assert(lineCount < MAX_CONF_COUNT);
+  char *lines[MAX_CONF_COUNT] = {0};
+  int lineCount = split_on(lines, code, newline);
+  assert(lineCount < MAX_CONF_COUNT);
 
-    IConfig *conf = NULL;
+  IConfig *conf = NULL;
 
-    int branchIndex = 0;
-    for (int currentLine = 0; currentLine < lineCount; ++currentLine) {
-        ir->configCount += 1;
+  int branchIndex = 0;
+  for (int currentLine = 0; currentLine < lineCount; ++currentLine) {
+    ir->configCount += 1;
 
-        char *lineContext = lines[currentLine];
+    char *lineContext = lines[currentLine];
 
-        // Skip the line if it is a comment
-        if (*lineContext == COMMENT_CHAR) {
-            continue;
-        }
-        if (*trim(lineContext) == '\0') {
-            continue;
-        }
-
-        // Determine whether or not this line is the declaration of a new
-        // configuration. If it is, create the new configuration in the
-        // machine struct and change 'c' to refer to it.
-        if (find_in_string(lineContext, ':')) {
-            char *name = strtok_r(NULL, configNameDelim, &lineContext);
-            name = trim(name);
-            if (is_empty(lineContext) && !name) {
-                code_error(c, "missing configuration name", currentLine);
-                lineContext = name;
-            };
-
-            if (!legal_config_name(name)) {
-                code_error(c, "configuration name must be all lower case", currentLine);
-            }
-
-            int prevIndex = find_config(ir->configs, name);
-            if (ir->configs[prevIndex].defined) {
-                code_error(c, "redefinition of configuration", currentLine);
-            }
-
-            int configIndex = insert_config(ir->configs, name);
-
-            // We have found a n actual declaration of the
-            // configuration, so we set it to defined.
-            // This does not mean that the definition
-            // is valid, only that it is not referenced
-            // by a different configuration without
-            // being defined.
-            ir->configs[configIndex].defined = true;
-            conf = &ir->configs[configIndex];
-
-            conf->name = name;
-            conf->definedOn = currentLine;
-
-            // Reset branch index since we are in a new configuration
-            branchIndex = 0;
-        }
-        if (conf == NULL) {
-            code_error(c, "missing configuration name (declare like 'begin: ...'",
-                    currentLine);
-            continue;
-        }
-        if (is_empty(lineContext)) {
-            code_error(c, "configuration is missing parameters", currentLine);
-            continue;
-        }
-
-        // Increment branch index for next pass
-        IBranch *branch = &conf->branches[branchIndex];
-        branch->definedOn = currentLine;
-        conf->branchCount += 1;
-
-        char *symbol = strtok_r(NULL, branchParamDelim, &lineContext);
-        symbol = trim(symbol);
-        branch->matchSymbol = symbol;
-
-        for (int i = 0; i < branchIndex; i++) {
-            if (strcmp(conf->branches[i].matchSymbol, symbol) == 0) {
-                code_error(c, "branch for given symbol is already defined",
-                        currentLine);
-            }
-        }
-        branchIndex++;
-
-        if (is_empty(symbol)) {
-            code_error(c, "branch is missing match symbol (first parameter)",
-                    currentLine);
-        };
-
-        char *opsString = strtok_r(NULL, branchParamDelim, &lineContext);
-        opsString = trim(opsString);
-
-        // Make copy to use for printing machine state
-        char *tmp = (char *)malloc(strlen(opsString) + 1);
-        strcpy(tmp, opsString);
-        branch->opsString = tmp;
-
-        char *ops[MAX_OPERATION_COUNT] = {0};
-        int opCount = split_on(ops, opsString, operationDelim);
-
-        for (int i = 0; i < opCount; ++i) {
-            branch->opCount += 1;
-            char *op = trim(ops[i]);
-            char *param = op + 1;
-
-            switch (*op) {
-                case 'N': {
-                          } break;
-                          // TODO Check that param does not exist
-                          // This could simply be a warning
-                case 'E': {
-                          } break;
-                          // TODO Check that param does not exist
-                          // This could simply be a warning
-                case 'P': {
-                              branch->ops[i].string = param;
-                          } break;
-                case 'R': {
-                              if (isdigit(*param)) {
-                                  branch->ops[i].number = *param - 48;
-                              }
-                          } break;
-                case 'L': {
-                              if (isdigit(*param)) {
-                                  branch->ops[i].number = *param - 48;
-                              }
-                          } break;
-                default: {
-                             // TODO Feil
-                         }
-            }
-            branch->ops[i].name = *op;
-        }
-
-        char *nextName = strtok_r(NULL, branchParamDelim, &lineContext);
-        nextName = trim(nextName);
-
-        bool hasNext = true;
-        if (is_empty(nextName)) {
-            code_error(c, "branch is missing next configuration (last parameter)",
-                    currentLine);
-            hasNext = false;
-        };
-
-        if (hasNext) {
-            int nextConfigIndex = find_config(ir->configs, nextName);
-            if (nextConfigIndex == NOT_DEFINED) {
-                nextConfigIndex = insert_config(ir->configs, nextName);
-                ir->configs[nextConfigIndex].definedOn = currentLine;
-            }
-
-            branch->next = &ir->configs[nextConfigIndex];
-        }
+    // Skip the line if it is a comment
+    if (*lineContext == COMMENT_CHAR) {
+      continue;
     }
-    // Iterate over branches of configs and check that their
-    // 'next' function is defined.
-    /* TODO TODO TODO
-       for (int ci = 0; ci < MAX_CONF_COUNT; ci++) {
-       char name = ir.configs[ci].name[0];
-       bool defined = ir.configs[ci].defined;
-       if (name && !defined) {
-       error(c, "a configuration is not properly defined", 0);
-       }
-       }
-       */
+    if (*trim(lineContext) == '\0') {
+      continue;
+    }
 
-    handle_errors(c);
-    c->parseInfo = *ir;
-    return ir;
+    // Determine whether or not this line is the declaration of a new
+    // configuration. If it is, create the new configuration in the
+    // machine struct and change 'c' to refer to it.
+    if (find_in_string(lineContext, ':')) {
+      char *name = strtok_r(NULL, configNameDelim, &lineContext);
+      name = trim(name);
+      if (is_empty(lineContext) && !name) {
+        code_error(c, "missing configuration name", currentLine);
+        lineContext = name;
+      };
+
+      if (!legal_config_name(name)) {
+        code_error(c, "configuration name must be all lower case", currentLine);
+      }
+
+      int prevIndex = find_config(ir->configs, name);
+      if (ir->configs[prevIndex].defined) {
+        code_error(c, "redefinition of configuration", currentLine);
+      }
+
+      int configIndex = insert_config(ir->configs, name);
+
+      // We have found a n actual declaration of the
+      // configuration, so we set it to defined.
+      // This does not mean that the definition
+      // is valid, only that it is not referenced
+      // by a different configuration without
+      // being defined.
+      ir->configs[configIndex].defined = true;
+      conf = &ir->configs[configIndex];
+
+      conf->name = name;
+      conf->definedOn = currentLine;
+
+      // Reset branch index since we are in a new configuration
+      branchIndex = 0;
+    }
+    if (conf == NULL) {
+      code_error(c, "missing configuration name (declare like 'begin: ...'",
+                 currentLine);
+      continue;
+    }
+    if (is_empty(lineContext)) {
+      code_error(c, "configuration is missing parameters", currentLine);
+      continue;
+    }
+
+    // Increment branch index for next pass
+    IBranch *branch = &conf->branches[branchIndex];
+    branch->definedOn = currentLine;
+    conf->branchCount += 1;
+
+    char *symbol = strtok_r(NULL, branchParamDelim, &lineContext);
+    symbol = trim(symbol);
+    branch->matchSymbol = symbol;
+
+    for (int i = 0; i < branchIndex; i++) {
+      if (strcmp(conf->branches[i].matchSymbol, symbol) == 0) {
+        code_error(c, "branch for given symbol is already defined",
+                   currentLine);
+      }
+    }
+    branchIndex++;
+
+    if (is_empty(symbol)) {
+      code_error(c, "branch is missing match symbol (first parameter)",
+                 currentLine);
+    };
+
+    char *opsString = strtok_r(NULL, branchParamDelim, &lineContext);
+    opsString = trim(opsString);
+
+    // Make copy to use for printing machine state
+    char *tmp = (char *)malloc(strlen(opsString) + 1);
+    strcpy(tmp, opsString);
+    branch->opsString = tmp;
+
+    char *ops[MAX_OPERATION_COUNT] = {0};
+    int opCount = split_on(ops, opsString, operationDelim);
+
+    for (int i = 0; i < opCount; ++i) {
+      branch->opCount += 1;
+      char *op = trim(ops[i]);
+      char *param = op + 1;
+
+      switch (*op) {
+        case 'N': {
+        } break;
+          // TODO Check that param does not exist
+          // This could simply be a warning
+        case 'E': {
+        } break;
+          // TODO Check that param does not exist
+          // This could simply be a warning
+        case 'P': {
+          branch->ops[i].string = param;
+        } break;
+        case 'R': {
+          if (isdigit(*param)) {
+            branch->ops[i].number = *param - 48;
+          }
+        } break;
+        case 'L': {
+          if (isdigit(*param)) {
+            branch->ops[i].number = *param - 48;
+          }
+        } break;
+        default: {
+          // TODO Feil
+        }
+      }
+      branch->ops[i].name = *op;
+    }
+
+    char *nextName = strtok_r(NULL, branchParamDelim, &lineContext);
+    nextName = trim(nextName);
+
+    bool hasNext = true;
+    if (is_empty(nextName)) {
+      code_error(c, "branch is missing next configuration (last parameter)",
+                 currentLine);
+      hasNext = false;
+    };
+
+    if (hasNext) {
+      int nextConfigIndex = find_config(ir->configs, nextName);
+      if (nextConfigIndex == NOT_DEFINED) {
+        nextConfigIndex = insert_config(ir->configs, nextName);
+        ir->configs[nextConfigIndex].definedOn = currentLine;
+      }
+
+      branch->next = &ir->configs[nextConfigIndex];
+    }
+  }
+  // Iterate over branches of configs and check that their
+  // 'next' function is defined.
+  /* TODO TODO TODO
+     for (int ci = 0; ci < MAX_CONF_COUNT; ci++) {
+     char name = ir.configs[ci].name[0];
+     bool defined = ir.configs[ci].defined;
+     if (name && !defined) {
+     error(c, "a configuration is not properly defined", 0);
+     }
+     }
+     */
+
+  handle_errors(c);
+  c->parseInfo = *ir;
+  return ir;
 }
 
 void right(Machine *m, int count) {
-    assert(m->pointer != TAPE_LENGTH);
-    assert(count > 0 && count < (TAPE_LENGTH - m->pointer));
-    m->pointer += count;
+  assert(m->pointer != TAPE_LENGTH);
+  assert(count > 0 && count < (TAPE_LENGTH - m->pointer));
+  m->pointer += count;
 }
 
 void left(Machine *m, int count) {
-    assert(m->pointer != 0);
-    // TODO fix den under
-    // assert(count > 0 && (TAPE_LENGTH - m->pointer) > count);
-    m->pointer -= count;
+  assert(m->pointer != 0);
+  // TODO fix den under
+  // assert(count > 0 && (TAPE_LENGTH - m->pointer) > count);
+  m->pointer -= count;
 }
 // The operations the machine can perform on the tape.
 void print(Machine *m, char *sym) {
-    assert(strlen(sym) > 0);
-    if (strlen(sym) > 1) {
-        while (*sym != '\0') {
-            m->tape[m->pointer] = *sym++;
-            right(m, 2);
-        }
-    } else {
-        m->tape[m->pointer] = *sym;
+  assert(strlen(sym) > 0);
+  if (strlen(sym) > 1) {
+    while (*sym != '\0') {
+      m->tape[m->pointer] = *sym++;
+      right(m, 2);
     }
+  } else {
+    m->tape[m->pointer] = *sym;
+  }
 }
 
 void erase(Machine *m) { m->tape[m->pointer] = 0; }
@@ -584,276 +581,272 @@ void erase(Machine *m) { m->tape[m->pointer] = 0; }
 char read(Machine *m) { return m->tape[m->pointer]; }
 
 void copy_n(size_t SourceACount, char *SourceA, size_t DestCount, char *Dest) {
-    for (int Index = 0; Index < SourceACount; ++Index) {
-        *Dest++ = *SourceA++;
-    }
-    *Dest++ = 0;
+  for (int Index = 0; Index < SourceACount; ++Index) {
+    *Dest++ = *SourceA++;
+  }
+  *Dest++ = 0;
 }
 
-void print_machine(IConfig *configInfo, IBranch *branchInfo, Machine *m, int topPointerAccessed, int lowerBound,
-        int upperBound, bool verbose) {
-    char outputBuffer[TAPE_LENGTH];  // Buffer used for printing
-    char pointerBuffer[TAPE_LENGTH];
+void print_machine(IConfig *configInfo, IBranch *branchInfo, Machine *m,
+                   int topPointerAccessed, int lowerBound, int upperBound,
+                   bool verbose) {
+  char outputBuffer[TAPE_LENGTH];  // Buffer used for printing
+  char pointerBuffer[TAPE_LENGTH];
 
-    int pointer = (m->pointer == 0) ? 1 : m->pointer;
+  int pointer = (m->pointer == 0) ? 1 : m->pointer;
 
-    for (int i = 0; i <= pointer; i++) {
-        pointerBuffer[i] = ' ';
-    }
+  for (int i = 0; i <= pointer; i++) {
+    pointerBuffer[i] = ' ';
+  }
 
-    printf("\n  $ %s:\t%s | %s | %s\n",
-            configInfo->name,
-            branchInfo->matchSymbol,
-            branchInfo->opsString,
-            branchInfo->next->name);
+  printf("\n  $ %s:\t%s | %s | %s\n", configInfo->name, branchInfo->matchSymbol,
+         branchInfo->opsString, branchInfo->next->name);
 
-    // On the first pass the pointer will be set to 0, but
-    // we want it to point on a blank space in the tape
-    strcpy(outputBuffer, m->tape);
-    outputBuffer[topPointerAccessed + 1] = '\0';
+  // On the first pass the pointer will be set to 0, but
+  // we want it to point on a blank space in the tape
+  strcpy(outputBuffer, m->tape);
+  outputBuffer[topPointerAccessed + 1] = '\0';
 
-    // +1 since we need to make up for the '[' character
-    pointerBuffer[pointer - lowerBound + 1] = 'v';
-    pointerBuffer[pointer - lowerBound +  2] = '\0';
+  // +1 since we need to make up for the '[' character
+  pointerBuffer[pointer - lowerBound + 1] = 'v';
+  pointerBuffer[pointer - lowerBound + 2] = '\0';
 
-    if (lowerBound != -1 || upperBound != -1) {
-        char boundBuffer[TAPE_LENGTH * 2];
-        outputBuffer[upperBound] = 0;
-        strcpy(boundBuffer, outputBuffer + lowerBound);
-        strcpy(outputBuffer, boundBuffer);
-        outputBuffer[lowerBound + upperBound] = '\0';
-    }
+  if (lowerBound != -1 || upperBound != -1) {
+    char boundBuffer[TAPE_LENGTH * 2];
+    outputBuffer[upperBound] = 0;
+    strcpy(boundBuffer, outputBuffer + lowerBound);
+    strcpy(outputBuffer, boundBuffer);
+    outputBuffer[lowerBound + upperBound] = '\0';
+  }
 
-    char leftLimit = '[';
-    char rightLimit = ']';
-    if (upperBound < topPointerAccessed) {
-        rightLimit = '>';
-    }
-    if (lowerBound > 0) {
-        leftLimit = '<';
-    }
+  char leftLimit = '[';
+  char rightLimit = ']';
+  if (upperBound < topPointerAccessed) {
+    rightLimit = '>';
+  }
+  if (lowerBound > 0) {
+    leftLimit = '<';
+  }
 
-    printf("  %s\n  %c%s%c\n\n",  pointerBuffer, leftLimit, outputBuffer, rightLimit);
+  printf("  %s\n  %c%s%c\n\n", pointerBuffer, leftLimit, outputBuffer,
+         rightLimit);
 }
 
 void run_machine(Context *context, Machine *m, int iterations, char *result,
-        bool verbose) {
-    int topPointerAccessed = 1;  // Value used for determining how much to print
+                 bool verbose) {
+  int topPointerAccessed = 1;  // Value used for determining how much to print
 
-    int window = 48;
-    int highBound = window;
-    int lowBound = 0;
+  int window = 48;
+  int highBound = window;
+  int lowBound = 0;
 
-    int configuration;
+  int configuration;
 
-    while (iterations --> 0) {
-        assert(m->pointer <= TAPE_LENGTH);
+  while (iterations-- > 0) {
+    assert(m->pointer <= TAPE_LENGTH);
 
-        Configuration config = m->configurations[configuration];
-        for (int branchIndex = 0; branchIndex < MAX_BRANCH_COUNT; branchIndex++)
-        {
-            char symbol = m->tape[m->pointer];
-            Branch branch = config.branches[branchIndex];
+    Configuration config = m->configurations[configuration];
+    for (int branchIndex = 0; branchIndex < MAX_BRANCH_COUNT; branchIndex++) {
+      char symbol = m->tape[m->pointer];
+      Branch branch = config.branches[branchIndex];
 
-            // Here we are checking whether or not we are in the correct branch
-            // if we are not, we will go on to the next iteration.
-            // If we are, we will execute the branch and move on to the next
-            // configuration
-            if (branch.matchSymbol == symbol ||
-                    (branch.matchSymbol == ANY && symbol == 0) ||
-                    (branch.matchSymbol == ANY && symbol == 1) ||
-                    (branch.matchSymbol == ELSE)) {
-
-                // Execute all operations in branch until a N
-                bool nop = false;
-                for (int operationIndex = 0; operationIndex < MAX_OPERATION_COUNT;
-                        ++operationIndex) {
-                    Operation operation = branch.ops[operationIndex];
-                    switch (operation.name) {
-                        case N: {
-                                    nop = true;
-                                } break;
-                        case P: {
-                                    print(m, operation.string);
-                                } break;
-                        case E: {
-                                    erase(m);
-                                } break;
-                        case R: {
-                                    right(m, operation.number);
-                                } break;
-                        case L: {
-                                    left(m, operation.number);
-                                } break;
-                    }
-                    if (nop) {
-                        break;
-                    }
-                }
-            } else {
-                continue;
-            }
-            // Change topPointerAccessed if we have
-            // touched a higher pointer.
-            // This is for printing purposes.
-            if (m->pointer > topPointerAccessed) {
-                topPointerAccessed = m->pointer;
-            }
-            // Adjust the window of the tape to print
-            // if we move out of the defined boundaries
-            if (m->pointer >= highBound || m->pointer <= lowBound) {
-                if (topPointerAccessed - m->pointer >= window / 2) {
-                    printf("more");
-                    highBound = m->pointer + window / 2;
-                    lowBound = m->pointer - window / 2;
-                } else {
-                    highBound = topPointerAccessed + 1;
-                    lowBound = highBound - window;
-                }
-            }
-            print_machine(config.info, branch.info, m, topPointerAccessed, lowBound, highBound, verbose);
-            configuration = branch.nextConfiguration;
+      // Here we are checking whether or not we are in the correct branch
+      // if we are not, we will go on to the next iteration.
+      // If we are, we will execute the branch and move on to the next
+      // configuration
+      if (branch.matchSymbol == symbol ||
+          (branch.matchSymbol == ANY && symbol == 0) ||
+          (branch.matchSymbol == ANY && symbol == 1) ||
+          (branch.matchSymbol == ELSE)) {
+        // Execute all operations in branch until a N
+        bool nop = false;
+        for (int operationIndex = 0; operationIndex < MAX_OPERATION_COUNT;
+             ++operationIndex) {
+          Operation operation = branch.ops[operationIndex];
+          switch (operation.name) {
+            case N: {
+              nop = true;
+            } break;
+            case P: {
+              print(m, operation.string);
+            } break;
+            case E: {
+              erase(m);
+            } break;
+            case R: {
+              right(m, operation.number);
+            } break;
+            case L: {
+              left(m, operation.number);
+            } break;
+          }
+          if (nop) {
             break;
+          }
         }
+      } else {
+        continue;
+      }
+      // Change topPointerAccessed if we have
+      // touched a higher pointer.
+      // This is for printing purposes.
+      if (m->pointer > topPointerAccessed) {
+        topPointerAccessed = m->pointer;
+      }
+      // Adjust the window of the tape to print
+      // if we move out of the defined boundaries
+      if (m->pointer >= highBound || m->pointer <= lowBound) {
+        if (topPointerAccessed - m->pointer >= window / 2) {
+          printf("more");
+          highBound = m->pointer + window / 2;
+          lowBound = m->pointer - window / 2;
+        } else {
+          highBound = topPointerAccessed + 1;
+          lowBound = highBound - window;
+        }
+      }
+      print_machine(config.info, branch.info, m, topPointerAccessed, lowBound,
+                    highBound, verbose);
+      configuration = branch.nextConfiguration;
+      break;
     }
+  }
 
-    // Here we want to print the result of the computation
-    // into a buffer for printing.
-    // We do this by writing every second value from the turing
-    // machine's tape into the result buffer (following turing's
-    // conventions).
+  // Here we want to print the result of the computation
+  // into a buffer for printing.
+  // We do this by writing every second value from the turing
+  // machine's tape into the result buffer (following turing's
+  // conventions).
 
-    int maxIndex = 2 * (int)floor(topPointerAccessed / 2) + 2;
-    int resultIndex = 0;
-    for (int tapeIndex = 0; tapeIndex < maxIndex; tapeIndex += 2) {
-        result[resultIndex++] = m->tape[tapeIndex];
-    }
+  int maxIndex = 2 * (int)floor(topPointerAccessed / 2) + 2;
+  int resultIndex = 0;
+  for (int tapeIndex = 0; tapeIndex < maxIndex; tapeIndex += 2) {
+    result[resultIndex++] = m->tape[tapeIndex];
+  }
 }
 
 Machine translate(IR *ir) {
-    Machine m;
+  Machine m;
 
-    for (int i = 0; i < TAPE_LENGTH; i++) {
-        m.tape[i] = NONE;
-    }
+  for (int i = 0; i < TAPE_LENGTH; i++) {
+    m.tape[i] = NONE;
+  }
 
-    for (int ci = 0; ci < ir->configCount; ci++) {
-        Configuration *conf = &m.configurations[ci];
-        IConfig iconf = ir->configs[ci];
-        conf->info = &ir->configs[ci];
+  for (int ci = 0; ci < ir->configCount; ci++) {
+    Configuration *conf = &m.configurations[ci];
+    IConfig iconf = ir->configs[ci];
+    conf->info = &ir->configs[ci];
 
-        // Iterate over each branch in each configuration
-        // and fill in its information from the ir
-        for (int bi = 0; bi < iconf.branchCount; bi++) {
-            Branch *branch = &conf->branches[bi];
-            IBranch ibranch = iconf.branches[bi];
-            branch->info = &ir->configs[ci].branches[bi];
+    // Iterate over each branch in each configuration
+    // and fill in its information from the ir
+    for (int bi = 0; bi < iconf.branchCount; bi++) {
+      Branch *branch = &conf->branches[bi];
+      IBranch ibranch = iconf.branches[bi];
+      branch->info = &ir->configs[ci].branches[bi];
 
-            // Set the value for the match symbol,
-            // translating keywords into their correlated value.
-            if (strcmp(ibranch.matchSymbol, "none") == 0) {
-                branch->matchSymbol = NONE;
-            } else if (strcmp(ibranch.matchSymbol, "any") == 0) {
-                branch->matchSymbol = ANY;
-            } else if (strcmp(ibranch.matchSymbol, "else") == 0) {
-                branch->matchSymbol = ELSE;
-            } else {
-                branch->matchSymbol = ibranch.matchSymbol[0];
-            }
+      // Set the value for the match symbol,
+      // translating keywords into their correlated value.
+      if (strcmp(ibranch.matchSymbol, "none") == 0) {
+        branch->matchSymbol = NONE;
+      } else if (strcmp(ibranch.matchSymbol, "any") == 0) {
+        branch->matchSymbol = ANY;
+      } else if (strcmp(ibranch.matchSymbol, "else") == 0) {
+        branch->matchSymbol = ELSE;
+      } else {
+        branch->matchSymbol = ibranch.matchSymbol[0];
+      }
 
-            // Determine the index of the next configuration
-            // by iterating over the configurations and finding
-            // the one with the correct name.
-            for (int ci = 0; ci < ir->configCount; ci++) {
-                if (ibranch.next->name == ir->configs[ci].name) {
-                    branch->nextConfiguration = ci;
-                }
-            }
-
-            // Fill in the operations for the current branch
-            for (int oi = 0; oi < ibranch.opCount; oi++) {
-                Operation *op = &branch->ops[oi];
-                IOperation iop = ibranch.ops[oi];
-                switch (iop.name) {
-                    case 'N': {
-                                  op->name = N;
-                              } break;
-                    case 'E': {
-                                  op->name = E;
-                              } break;
-                    case 'P': {
-                                  op->name = P;
-                                  op->string = iop.string;
-                              } break;
-                    case 'R': {
-                                  op->name = R;
-                                  op->number = iop.number;
-                                  if (iop.number == 0) {
-                                      op->number = 1;
-                                  }
-                              } break;
-                    case 'L': {
-                                  op->name = L;
-                                  if (iop.number == 0) {
-                                      op->number = 1;
-                                  }
-                              } break;
-                }
-            }
+      // Determine the index of the next configuration
+      // by iterating over the configurations and finding
+      // the one with the correct name.
+      for (int ci = 0; ci < ir->configCount; ci++) {
+        if (ibranch.next->name == ir->configs[ci].name) {
+          branch->nextConfiguration = ci;
         }
+      }
+
+      // Fill in the operations for the current branch
+      for (int oi = 0; oi < ibranch.opCount; oi++) {
+        Operation *op = &branch->ops[oi];
+        IOperation iop = ibranch.ops[oi];
+        switch (iop.name) {
+          case 'N': {
+            op->name = N;
+          } break;
+          case 'E': {
+            op->name = E;
+          } break;
+          case 'P': {
+            op->name = P;
+            op->string = iop.string;
+          } break;
+          case 'R': {
+            op->name = R;
+            op->number = iop.number;
+            if (iop.number == 0) {
+              op->number = 1;
+            }
+          } break;
+          case 'L': {
+            op->name = L;
+            if (iop.number == 0) {
+              op->number = 1;
+            }
+          } break;
+        }
+      }
     }
-    return m;
+  }
+  return m;
 }
 
 int main(int argc, char *argv[]) {
-    Context c = {0};
+  Context c = {0};
 
-    int timesToRun = -1;
-    char *filename = 0;
-    bool verbose = false;
+  int timesToRun = -1;
+  char *filename = 0;
+  bool verbose = false;
 
-    for (int i = 1; i < argc; ++i) {
-        if (is_number(argv[i])) {
-            char *endPtr;
-            timesToRun = strtol(argv[i], &endPtr, 10);
-        } else if (*argv[i] == '-') {
-            if (*(argv[i] + 1) == 'v') {
-                verbose = true;
-            }
+  for (int i = 1; i < argc; ++i) {
+    if (is_number(argv[i])) {
+      char *endPtr;
+      timesToRun = strtol(argv[i], &endPtr, 10);
+    } else if (*argv[i] == '-') {
+      if (*(argv[i] + 1) == 'v') {
+        verbose = true;
+      }
 
-        } else if (!filename) {
-            filename = argv[i];
-        }
+    } else if (!filename) {
+      filename = argv[i];
     }
+  }
 
-    if (filename == 0) {
-        error(&c, "no filename specified", FILE_ERROR);
-    }
+  if (filename == 0) {
+    error(&c, "no filename specified", FILE_ERROR);
+  }
 
-    if (timesToRun == -1) {
-        error(&c, "please specify number of passes to make", FILE_ERROR);
-    }
+  if (timesToRun == -1) {
+    error(&c, "please specify number of passes to make", FILE_ERROR);
+  }
 
-    char *bytecode = read_source(&c, filename);
+  char *bytecode = read_source(&c, filename);
 
-    IR ir = {0};
+  IR ir = {0};
 
-    parse(&c, &ir, bytecode);
-    Machine m = translate(&ir);
+  parse(&c, &ir, bytecode);
+  Machine m = translate(&ir);
 
-    char result[256];
-    run_machine(&c, &m, timesToRun, result, verbose);
+  char result[256];
+  run_machine(&c, &m, timesToRun, result, verbose);
 
-    char stringResult[256];
-    parse_string(stringResult, result);
+  char stringResult[256];
+  parse_string(stringResult, result);
 
-    float floatResult = parse_binary_point_value(result);
+  float floatResult = parse_binary_point_value(result);
 
-    // Prints interpretations of the result
-    printf("\n Binary:\t%s\n String:\t%s\n Float: \t%f\n",
-            result,
-            stringResult,
-            floatResult);
+  // Prints interpretations of the result
+  printf("\n Binary:\t%s\n String:\t%s\n Float: \t%f\n", result, stringResult,
+         floatResult);
 
-    return 0;
+  return 0;
 }

--- a/alan.c
+++ b/alan.c
@@ -1,20 +1,3 @@
-/*
- * Hvor vi slapp sist..
- *
- * Redefinerte parse-funksjonen til å lage en IR i stedet for å konstruere
- * Machine på direkten.
- *
- *
- * Nå må vi fikse
- * TODO Bytt ut trim-funksjonen
- * TODO Fix printing av tilstand
- * TODO Ordne feilhåndtering for parsing av opersjoner
- * TODO Ordne andre feilmeldinger for parsing
- * TODO Feilmelding for runtime når maskinen ikke matcher på noe symbol
- * TODO Organiser denne filen
- * TODO Fiks readme
- */
-
 #define _CRT_SECURE_NO_WARNINGS 1
 #if defined(_MSC_VER)  // Check if we are using a windows compiler
 #define strtok_r strtok_s

--- a/alan.c
+++ b/alan.c
@@ -4,6 +4,7 @@
  * Redefinerte parse-funksjonen til å lage en IR i stedet for å konstruere
  * Machine på direkten.
  *
+ *
  * Nå må vi fikse
  * TODO Parsing av operasjoner
  * TODO Oversettelse til bytekode
@@ -35,6 +36,7 @@
 #define NONE ' '
 #define COMMENT_CHAR '!'
 #define ELSE 0xff
+#define ANY 0xfe
 
 #define WINDOWSIZE 32
 
@@ -56,30 +58,30 @@ typedef enum Op { N = 0, P, E, R, L } Op;
 // https://en.wikipedia.org/wiki/Flexible_array_member
 
 typedef struct Operation {
-  Op op;
-  union {
-    char *string;
-    int number;
-  } parameter;
+    Op name;
+    union {
+        char *string;
+        int number;
+    };
 } Operation;
 
 typedef struct Branch {
-  char matchSymbol;
-  int nextConfiguration;
-  Operation operations[MAX_OPERATION_COUNT];
+    char matchSymbol;
+    int nextConfiguration;
+    Operation ops[MAX_OPERATION_COUNT];
 } Branch;
 
 typedef struct Configuration {
-  Branch branch[MAX_BRANCH_COUNT];
+    Branch branches[MAX_BRANCH_COUNT];
 } Configuration;
 
 typedef struct Machine {
-  int pointer;
-  char tape[TAPE_LENGTH];
+    int pointer;
+    char tape[TAPE_LENGTH];
 
-  int configuration;
-  int branch;
-  Configuration configurations[MAX_CONF_COUNT];
+    int configuration;
+    int branch;
+    Configuration configurations[MAX_CONF_COUNT];
 
 } Machine;
 
@@ -89,442 +91,485 @@ typedef struct Machine {
  * and allows us to print detailed information at runtime.
  */
 typedef struct IOperation {
-  char op;
-  bool isNum;
-  char *parameter;
+    char name;
+    bool isNum;
+    union {
+        char *string;
+        int number;
+    };
 } IOperation;
 
 typedef struct IBranch {
-  int definedOn;
-  char *matchSymbol;
-  IConfig *next;
-  IOperation ops[MAX_OPERATION_COUNT];
+    int definedOn;
+    char *matchSymbol;
+    IConfig *next;
+    int opCount;
+    IOperation ops[MAX_OPERATION_COUNT];
 } IBranch;
 
 typedef struct IConfig {
-  int definedOn;
-  bool defined;
-  char *name;
-  IBranch branches[MAX_BRANCH_COUNT];
+    int definedOn;
+    bool defined;
+    char *name;
+    int branchCount;
+    IBranch branches[MAX_BRANCH_COUNT];
 } IConfig;
 
 typedef struct IR {
-  IConfig configs[MAX_CONF_COUNT];
+    int configCount;
+    IConfig configs[MAX_CONF_COUNT];
 } IR;
 
 typedef struct Error {
-  char *message;
-  int line;
+    char *message;
+    int line;
 } Error;
 
 typedef struct Context {
-  IR parseInfo;
+    IR parseInfo;
 
-  bool error;
-  bool errorOverflow;
-  int nextError;
-  Error errors[MAX_ERROR];
+    bool error;
+    bool errorOverflow;
+    int nextError;
+    Error errors[MAX_ERROR];
 } Context;
 
 char *trim(char *str) {
-  // TODO Write a simpler version of this
-  // https://stackoverflow.com/questions/122616/how-do-i-trim-leading-trailing-whitespace-in-a-standard-way
-  size_t len = 0;
-  char *frontp = str;
-  char *endp = NULL;
+    // TODO Write a simpler version of this
+    // https://stackoverflow.com/questions/122616/how-do-i-trim-leading-trailing-whitespace-in-a-standard-way
+    size_t len = 0;
+    char *frontp = str;
+    char *endp = NULL;
 
-  if (str == NULL) {
-    return NULL;
-  }
-  if (str[0] == '\0') {
+    if (str == NULL) {
+        return NULL;
+    }
+    if (str[0] == '\0') {
+        return str;
+    }
+
+    len = strlen(str);
+    endp = str + len;
+
+    /* Move the front and back pointers to address the first non-whitespace
+     * characters from each end.
+     */
+    while (isspace((unsigned char)*frontp)) {
+        ++frontp;
+    }
+    if (endp != frontp) {
+        while (isspace((unsigned char)*(--endp)) && endp != frontp) {
+        }
+    }
+
+    if (frontp != str && endp == frontp)
+        *str = '\0';
+    else if (str + len - 1 != endp)
+        *(endp + 1) = '\0';
+
+    /* Shift the string so that it starts at str so that if it's dynamically
+     * allocated, we can still free it on the returned pointer.  Note the reuse
+     * of endp to mean the front of the string buffer now.
+     */
+    endp = str;
+    if (frontp != str) {
+        while (*frontp) {
+            *endp++ = *frontp++;
+        }
+        *endp = '\0';
+    }
+
     return str;
-  }
+}
 
-  len = strlen(str);
-  endp = str + len;
-
-  /* Move the front and back pointers to address the first non-whitespace
-   * characters from each end.
-   */
-  while (isspace((unsigned char)*frontp)) {
-    ++frontp;
-  }
-  if (endp != frontp) {
-    while (isspace((unsigned char)*(--endp)) && endp != frontp) {
+void code_error(Context *c, char *msg, int line) {
+    c->error = true;
+    if (c->nextError < MAX_ERROR) {
+        // TODO bound check and assert
+        c->errors[c->nextError].message = msg;
+        c->errors[c->nextError].line = line;
+        c->nextError++;
+    } else {
+        c->errorOverflow = true;
     }
-  }
-
-  if (frontp != str && endp == frontp)
-    *str = '\0';
-  else if (str + len - 1 != endp)
-    *(endp + 1) = '\0';
-
-  /* Shift the string so that it starts at str so that if it's dynamically
-   * allocated, we can still free it on the returned pointer.  Note the reuse
-   * of endp to mean the front of the string buffer now.
-   */
-  endp = str;
-  if (frontp != str) {
-    while (*frontp) {
-      *endp++ = *frontp++;
-    }
-    *endp = '\0';
-  }
-
-  return str;
 }
 
 void error(Context *c, char *msg, int line) {
-  c->error = true;
-  if (c->nextError < MAX_ERROR) {
-    // TODO bound check and assert
-    c->errors[c->nextError].message = msg;
-    c->errors[c->nextError].line = line;
-    c->nextError++;
-  } else {
-    c->errorOverflow = true;
-  }
+    c->error = true;
+    if (c->nextError < MAX_ERROR) {
+        // TODO bound check and assert
+        c->errors[c->nextError].message = msg;
+        c->errors[c->nextError].line = line;
+        c->nextError++;
+    } else {
+        c->errorOverflow = true;
+    }
 }
 
 void warning(Context *c, char *msg, int line) {
-  if (c->nextError < MAX_ERROR) {
-    // TODO bound check and assert
-    c->errors[c->nextError].message = msg;
-    c->errors[c->nextError].line = line;
-    c->nextError++;
-  } else {
-    c->errorOverflow = true;
-  }
+    if (c->nextError < MAX_ERROR) {
+        // TODO bound check and assert
+        c->errors[c->nextError].message = msg;
+        c->errors[c->nextError].line = line;
+        c->nextError++;
+    } else {
+        c->errorOverflow = true;
+    }
 }
 
 void handle_errors(Context *c) {
-  for (int i = 0; i < c->nextError; i++) {
-    int line = c->errors[i].line;
-    char *msg = c->errors[i].message;
-    if (line == FILE_ERROR) {
-      fprintf(stderr, "\n\tFile error:\n\t  %s\n", msg);
-    } else if (line == ARGUMENT_ERROR) {
-      fprintf(stderr, "\n\tArgument error:\n\t  %s\n", msg);
-    } else {
-      fprintf(stderr, "\n\tError in line %i:\n\t  %s\n", ++line, msg);
+    for (int i = 0; i < c->nextError; i++) {
+        int line = c->errors[i].line;
+        char *msg = c->errors[i].message;
+        if (line == FILE_ERROR) {
+            fprintf(stderr, "\n\tFile error:\n\t  %s\n", msg);
+        } else if (line == ARGUMENT_ERROR) {
+            fprintf(stderr, "\n\tArgument error:\n\t  %s\n", msg);
+        } else {
+            fprintf(stderr, "\n\tError in line %i:\n\t  %s\n", ++line, msg);
+        }
     }
-  }
-  if (c->error) {
-    exit(EXIT_FAILURE);
-  }
+    if (c->error) {
+        exit(EXIT_FAILURE);
+    }
 }
 
 char *read_source(Context *c, char *filename) {
-  // https://www.tutorialspoint.com/cprogramming/c_file_io.htm
-  FILE *file =
-      fopen(filename, "rb");  // TODO Might be problematic outside of windows
-  if (!file) {
-    error(c, "File could not be loaded. Does it exist?", FILE_ERROR);
-    return 0;
-  };
-  fseek(file, 0, SEEK_END);
-  long fsize = ftell(file);
-  fseek(file, 0, SEEK_SET);
+    // https://www.tutorialspoint.com/cprogramming/c_file_io.htm
+    FILE *file =
+        fopen(filename, "rb");  // TODO Might be problematic outside of windows
+    if (!file) {
+        error(c, "File could not be loaded. Does it exist?", FILE_ERROR);
+        return 0;
+    };
+    fseek(file, 0, SEEK_END);
+    long fsize = ftell(file);
+    fseek(file, 0, SEEK_SET);
 
-  char *bytecode = (char *)malloc(fsize + 1);
-  fread(bytecode, fsize, 1, file);
-  fclose(file);
-  bytecode[fsize] = 0;  // Add line-terminator
+    char *bytecode = (char *)malloc(fsize + 1);
+    fread(bytecode, fsize, 1, file);
+    fclose(file);
+    bytecode[fsize] = 0;  // Add line-terminator
 
-  return bytecode;
+    return bytecode;
 }
 
 float parse_binary_point_value(char *numstring) {
-  float sum = 0;
-  char *c = numstring;
-  float n = 1;
+    float sum = 0;
+    char *c = numstring;
+    float n = 1;
 
-  while (*c != '\0') {
-    float i = (float)(*c++ - 48);
-    sum += i * 1.0f / powf(2.0f, n);
-    n *= 2;
-  }
+    while (*c != '\0') {
+        float i = (float)(*c++ - 48);
+        sum += i * 1.0f / powf(2.0f, n);
+        n *= 2;
+    }
 
-  return sum;
+    return sum;
 }
 
 char *parse_string(char *result, char *binary) {
-  char *c = binary;
-  int resultIndex = 0;
-  while (*c != 0) {
-    int n = 128;
-    char sum = 0;
-    for (int i = 0; i < 8; i++) {
-      if (*c == 0) {
-        break;
-      }
-      if (*c == '1') {
-        assert(n < 0xff);
-        sum += (char)n * 1;
-      }
-      n /= 2;
-      c++;
+    char *c = binary;
+    int resultIndex = 0;
+    while (*c != 0) {
+        int n = 128;
+        char sum = 0;
+        for (int i = 0; i < 8; i++) {
+            if (*c == 0) {
+                break;
+            }
+            if (*c == '1') {
+                assert(n < 0xff);
+                sum += (char)n * 1;
+            }
+            n /= 2;
+            c++;
+        }
+        result[resultIndex++] = sum;
     }
-    result[resultIndex++] = sum;
-  }
-  return result;
+    return result;
 }
 
 int insert_config(IConfig array[MAX_CONF_COUNT], char *str) {
-  for (int i = 0; i < MAX_CONF_COUNT; i++) {
-    if (array[i].name == NULL) {
-      // We have found an empty spot,
-      // which means the identifier is not in the list,
-      // so we put it here
-      // TODO handle bas size
-      array[i].name = str;
-      return i;
+    for (int i = 0; i < MAX_CONF_COUNT; i++) {
+        if (array[i].name == NULL) {
+            // We have found an empty spot,
+            // which means the identifier is not in the list,
+            // so we put it here
+            // TODO handle bas size
+            array[i].name = str;
+            return i;
 
-    } else if (strcmp(array[i].name, str) == 0) {
-      // The identifier already exists, so we return its return index
-      return i;
+        } else if (strcmp(array[i].name, str) == 0) {
+            // The identifier already exists, so we return its return index
+            return i;
+        }
+        continue;
     }
-    continue;
-  }
-  assert(false);
-  return -1;
+    assert(false);
+    return -1;
 }
 
 int find_config(IConfig array[MAX_CONF_COUNT], char *str) {
-  for (int i = 0; i < MAX_CONF_COUNT; i++) {
-    if (array[i].name == NULL) {
-      continue;
+    for (int i = 0; i < MAX_CONF_COUNT; i++) {
+        if (array[i].name == NULL) {
+            continue;
+        }
+        if (strcmp(array[i].name, str) == 0) {
+            // The identifier already exists, so we return its return index
+            return i;
+        }
+        continue;
     }
-    if (strcmp(array[i].name, str) == 0) {
-      // The identifier already exists, so we return its return index
-      return i;
-    }
-    continue;
-  }
-  return -1;
+    return -1;
 }
 
 int split_on(char *slots[], char *text, char *delimiter) {
-  char *context;
+    char *context;
 
-  int index = 0;
-  char *unit = strtok_r(text, delimiter, &context);
-  while (unit != NULL) {
-    slots[index++] = unit;
-    unit = strtok_r(NULL, delimiter, &context);
-  }
-  return index;
+    int index = 0;
+    char *unit = strtok_r(text, delimiter, &context);
+    while (unit != NULL) {
+        slots[index++] = unit;
+        unit = strtok_r(NULL, delimiter, &context);
+    }
+    return index;
 }
 
 bool find_in_string(char *string, char symbol) {
-  char *c;
-  for (c = string; *c != '\0'; c++) {
-    if (*c == symbol) {
-      return true;
+    char *c;
+    for (c = string; *c != '\0'; c++) {
+        if (*c == symbol) {
+            return true;
+        }
     }
-  }
-  return false;
+    return false;
 }
 
 int is_number(char *string) {
-  char *c;
-  for (c = string; *c != '\0'; c++) {
-    if (!isdigit((int)*c)) {
-      return false;
+    char *c;
+    for (c = string; *c != '\0'; c++) {
+        if (!isdigit((int)*c)) {
+            return false;
+        }
     }
-  }
-  return true;
+    return true;
 }
 
 bool is_empty(char *string) { return string == NULL || string[0] == '\0'; }
 
 bool legal_config_name(char *string) {
-  char *c;
-  for (c = string; *c != '\0'; c++) {
-    if (islower((int)*c) || *c == ' ') {
-      continue;
+    char *c;
+    for (c = string; *c != '\0'; c++) {
+        if (islower((int)*c) || *c == ' ') {
+            continue;
+        }
+        return false;
     }
-    return false;
-  }
-  return true;
+    return true;
 }
 
 IR *parse(Context *c, IR *ir, char *code) {
-  // Definer delimitere
-  char newline[] = "\n";
-  char commentDelim[] = "!";
-  char configNameDelim[] = ":";
-  char branchDelim[] = ";";
-  char inBranchDelim[] = "|";
-  char operationDelim[] = ",";
+    // Definer delimitere
+    char newline[] = "\n";
+    char commentDelim[] = "!";
+    char configNameDelim[] = ":";
+    char branchDelim[] = ";";
+    char branchParamDelim[] = "|";
+    char operationDelim[] = ",";
 
-  char *lines[MAX_CONF_COUNT] = {0};
-  int lineCount = split_on(lines, code, newline);
-  assert(lineCount < MAX_CONF_COUNT);
+    char *lines[MAX_CONF_COUNT] = {0};
+    int lineCount = split_on(lines, code, newline);
+    assert(lineCount < MAX_CONF_COUNT);
 
-  IConfig *conf = NULL;
+    IConfig *conf = NULL;
 
-  int branchIndex = 0;
-  for (int currentLine = 0; currentLine < lineCount; ++currentLine) {
-    char *lineContext = lines[currentLine];
+    int branchIndex = 0;
+    for (int currentLine = 0; currentLine < lineCount; ++currentLine) {
+        ir->configCount += 1;
 
-    // Skip the line if it is a comment
-    if (*lineContext == COMMENT_CHAR) {
-      continue;
+        char *lineContext = lines[currentLine];
+
+        // Skip the line if it is a comment
+        if (*lineContext == COMMENT_CHAR) {
+            continue;
+        }
+        if (*trim(lineContext) == '\0') {
+            continue;
+        }
+
+        // Determine whether or not this line is the declaration of a new
+        // configuration. If it is, create the new configuration in the
+        // machine struct and change 'c' to refer to it.
+        if (find_in_string(lineContext, ':')) {
+            char *name = strtok_r(NULL, configNameDelim, &lineContext);
+            name = trim(name);
+            if (is_empty(lineContext) && !name) {
+                code_error(c, "missing configuration name", currentLine);
+                lineContext = name;
+            };
+
+            if (!legal_config_name(name)) {
+                code_error(c, "configuration name must be all lower case", currentLine);
+            }
+
+            int prevIndex = find_config(ir->configs, name);
+            if (ir->configs[prevIndex].defined) {
+                code_error(c, "redefinition of configuration", currentLine);
+            }
+
+            int configIndex = insert_config(ir->configs, name);
+
+            // We have found a n actual declaration of the
+            // configuration, so we set it to defined.
+            // This does not mean that the definition
+            // is valid, only that it is not referenced
+            // by a different configuration without
+            // being defined.
+            ir->configs[configIndex].defined = true;
+            conf = &ir->configs[configIndex];
+
+            conf->name = name;
+            conf->definedOn = currentLine;
+
+            // Reset branch index since we are in a new configuration
+            branchIndex = 0;
+        }
+        if (conf == NULL) {
+            code_error(c, "missing configuration name (declare like 'begin: ...'",
+                    currentLine);
+            continue;
+        }
+        if (is_empty(lineContext)) {
+            code_error(c, "configuration is missing parameters", currentLine);
+            continue;
+        }
+
+        // Increment branch index for next pass
+        IBranch *branch = &conf->branches[branchIndex];
+        branch->definedOn = currentLine;
+        conf->branchCount += 1;
+
+        char *symbol = strtok_r(NULL, branchParamDelim, &lineContext);
+        symbol = trim(symbol);
+        branch->matchSymbol = symbol;
+
+        for (int i = 0; i < branchIndex; i++) {
+            if (strcmp(conf->branches[i].matchSymbol, symbol) == 0) {
+                code_error(c, "branch for given symbol is already defined",
+                        currentLine);
+            }
+        }
+        branchIndex++;
+
+        if (is_empty(symbol)) {
+            code_error(c, "branch is missing match symbol (first parameter)",
+                    currentLine);
+        };
+
+        char *opsString = strtok_r(NULL, branchParamDelim, &lineContext);
+        opsString = trim(opsString);
+
+        char *ops[MAX_OPERATION_COUNT] = {0};
+        int opCount = split_on(ops, opsString, operationDelim);
+
+        for (int i = 0; i < opCount; ++i) {
+            branch->opCount += 1;
+            char *op = trim(ops[i]);
+            char *param = op + 1;
+
+            switch (*op) {
+                case 'N': {
+                          } break;
+                          // TODO Check that param does not exist
+                          // This could simply be a warning
+                case 'E': {
+                          } break;
+                          // TODO Check that param does not exist
+                          // This could simply be a warning
+                case 'P': {
+                              branch->ops[i].string = param;
+                          } break;
+                case 'R': {
+                              if (isdigit(*param)) {
+                                  // TODO error
+                              }
+                              branch->ops[i].isNum = true;
+                              branch->ops[i].number = *param - 48;
+                          } break;
+                case 'L': {
+                              if (isdigit(*param)) {
+                                  // TODO error
+                              }
+                              branch->ops[i].isNum = true;
+                              branch->ops[i].number = *param - 48;
+                          } break;
+                default: {
+                             // TODO Feil
+                         }
+            }
+            branch->ops[i].name = *op;
+        }
+
+        char *nextName = strtok_r(NULL, branchParamDelim, &lineContext);
+        nextName = trim(nextName);
+
+        bool hasNext = true;
+        if (is_empty(nextName)) {
+            code_error(c, "branch is missing next configuration (last parameter)",
+                    currentLine);
+            hasNext = false;
+        };
+
+        if (hasNext) {
+            int nextConfigIndex = find_config(ir->configs, nextName);
+            if (nextConfigIndex == NOT_DEFINED) {
+                nextConfigIndex = insert_config(ir->configs, nextName);
+                ir->configs[nextConfigIndex].definedOn = currentLine;
+            }
+
+            branch->next = &ir->configs[nextConfigIndex];
+        }
     }
-    if (*trim(lineContext) == '\0') {
-      continue;
-    }
+    // Iterate over branches of configs and check that their
+    // 'next' function is defined.
+    /* TODO TODO TODO
+       for (int ci = 0; ci < MAX_CONF_COUNT; ci++) {
+       char name = ir.configs[ci].name[0];
+       bool defined = ir.configs[ci].defined;
+       if (name && !defined) {
+       error(c, "a configuration is not properly defined", 0);
+       }
+       }
+       */
 
-    // Determine whether or not this line is the declaration of a new
-    // configuration. If it is, create the new configuration in the
-    // machine struct and change 'c' to refer to it.
-    if (find_in_string(lineContext, ':')) {
-      char *name = strtok_r(NULL, configNameDelim, &lineContext);
-      name = trim(name);
-      if (is_empty(lineContext) && !name) {
-        error(c, "missing configuration name", currentLine);
-        lineContext = name;
-      };
-
-      if (!legal_config_name(name)) {
-        error(c, "configuration name must be all lower case", currentLine);
-      }
-
-      int prevIndex = find_config(ir->configs, name);
-      if (ir->configs[prevIndex].defined) {
-        error(c, "redefinition of configuration", currentLine);
-      }
-
-      int configIndex = insert_config(ir->configs, name);
-
-      // We have found a n actual declaration of the
-      // configuration, so we set it to defined.
-      // This does not mean that the definition
-      // is valid, only that it is not referenced
-      // by a different configuration without
-      // being defined.
-      ir->configs[configIndex].defined = true;
-      conf = &ir->configs[configIndex];
-
-      conf->name = name;
-      conf->definedOn = currentLine;
-
-      // Reset branch index since we are in a new configuration
-      branchIndex = 0;
-    }
-    if (conf == NULL) {
-      error(c, "missing configuration name (declare like 'begin: ...'",
-            currentLine);
-      continue;
-    }
-    if (is_empty(lineContext)) {
-      error(c, "configuration is missing parameters", currentLine);
-      continue;
-    }
-
-    // Increment branch index for next pass
-    IBranch *branch = &conf->branches[branchIndex];
-    branch->definedOn = currentLine;
-
-    char *symbol = strtok_r(NULL, inBranchDelim, &lineContext);
-    symbol = trim(symbol);
-    branch->matchSymbol = symbol;
-
-    for (int i = 0; i < branchIndex; i++) {
-      if (strcmp(conf->branches[i].matchSymbol, symbol) == 0) {
-        error(c, "branch for given symbol is already defined", currentLine);
-      }
-    }
-    branchIndex++;
-
-    if (is_empty(symbol)) {
-      error(c, "branch is missing match symbol (first parameter)", currentLine);
-    };
-
-    char *opsString = strtok_r(NULL, inBranchDelim, &lineContext);
-    opsString = trim(opsString);
-
-    char *ops[MAX_OPERATION_COUNT] = {0};
-    int opCount = split_on(ops, opsString, operationDelim);
-
-    for (int i = 0; i < opCount; ++i) {
-      char *op = trim(ops[i]);
-      char *param = op + 1;
-
-      if (*op == 'N' || *op != 'E') {
-        // TODO Check that param does not exist
-        // This could simply be a warning
-      } else if (*op != 'P') {
-        // TODO Check that there is a parameter
-      } else if (*op == 'R' || *op == 'L') {
-        branch->ops[i].isNum = true;
-        // TODO Check that the argument is a number or blank
-      } else {
-        // TODO Illegal 'function' name
-      }
-      branch->ops[i].op = *op;
-      branch->ops[i].parameter = param;
-    }
-    char *nextName = strtok_r(NULL, inBranchDelim, &lineContext);
-    nextName = trim(nextName);
-
-    bool hasNext = true;
-    if (is_empty(nextName)) {
-      error(c, "branch is missing next configuration (last parameter)",
-            currentLine);
-      hasNext = false;
-    };
-
-    if (hasNext) {
-      int nextConfigIndex = find_config(ir->configs, nextName);
-      if (nextConfigIndex == NOT_DEFINED) {
-        nextConfigIndex = insert_config(ir->configs, nextName);
-        ir->configs[nextConfigIndex].definedOn = currentLine;
-      }
-
-      branch->next = &ir->configs[nextConfigIndex];
-    }
-  }
-  // Iterate over branches of configs and check that their
-  // 'next' function is defined.
-  /* TODO TODO TODO
-     for (int ci = 0; ci < MAX_CONF_COUNT; ci++) {
-     char name = ir.configs[ci].name[0];
-     bool defined = ir.configs[ci].defined;
-     if (name && !defined) {
-     error(c, "a configuration is not properly defined", 0);
-     }
-     }
-     */
-
-  // TODO handle_errors(c);
-  return ir;
+    handle_errors(c);
+    return ir;
 }
 
 void right(Machine *m, int count) {
-  assert(m->pointer != TAPE_LENGTH);
-  assert(count > 0 && count < (TAPE_LENGTH - m->pointer));
-  m->pointer += count;
+    assert(m->pointer != TAPE_LENGTH);
+    assert(count > 0 && count < (TAPE_LENGTH - m->pointer));
+    m->pointer += count;
 }
 
 void left(Machine *m, int count) {
-  assert(m->pointer != 0);
-  // TODO fix den under
-  // assert(count > 0 && (TAPE_LENGTH - m->pointer) > count);
-  m->pointer -= count;
+    assert(m->pointer != 0);
+    // TODO fix den under
+    // assert(count > 0 && (TAPE_LENGTH - m->pointer) > count);
+    m->pointer -= count;
 }
 // The operations the machine can perform on the tape.
 void print(Machine *m, char *sym) {
-  assert(strlen(sym) > 0);
-  if (strlen(sym) > 1) {
-    while (*sym != 0) {
-      m->tape[m->pointer] = *sym++;
-      right(m, 2);
+    assert(strlen(sym) > 0);
+    if (strlen(sym) > 1) {
+        while (*sym != 0) {
+            m->tape[m->pointer] = *sym++;
+            right(m, 2);
+        }
+    } else {
+        m->tape[m->pointer] = *sym;
     }
-  } else {
-    m->tape[m->pointer] = *sym;
-  }
 }
 
 void erase(Machine *m) { m->tape[m->pointer] = 0; }
@@ -532,10 +577,10 @@ void erase(Machine *m) { m->tape[m->pointer] = 0; }
 char read(Machine *m) { return m->tape[m->pointer]; }
 
 void copy_n(size_t SourceACount, char *SourceA, size_t DestCount, char *Dest) {
-  for (int Index = 0; Index < SourceACount; ++Index) {
-    *Dest++ = *SourceA++;
-  }
-  *Dest++ = 0;
+    for (int Index = 0; Index < SourceACount; ++Index) {
+        *Dest++ = *SourceA++;
+    }
+    *Dest++ = 0;
 }
 
 /*
@@ -590,218 +635,210 @@ printf("%s \n[%s]\n\n", pointerBuffer, outputBuffer);
 */
 
 void run_machine(Context *context, Machine *m, int iterations, char *result,
-                 bool verbose) {
-  int topPointerAccessed = 1;  // Value used for determining how much to print
+        bool verbose) {
+    int topPointerAccessed = 1;  // Value used for determining how much to print
 
-  int window = 48;
-  int highBound = window;
-  int lowBound = 0;
+    int window = 48;
+    int highBound = window;
+    int lowBound = 0;
 
-  while (iterations-- > 0) {
-    assert(m->pointer <= TAPE_LENGTH);
+    while (iterations --> 0) {
+        assert(m->pointer <= TAPE_LENGTH);
 
-    Configuration c = m->configurations[m->configuration];
-    for (int branchIndex = 0; branchIndex < MAX_BRANCH_COUNT; branchIndex++) {
-      char symbol = m->tape[m->pointer];
-      Branch branch = c.branch[branchIndex];
+        Configuration c = m->configurations[m->configuration];
+        for (int branchIndex = 0; branchIndex < MAX_BRANCH_COUNT; branchIndex++)
+        { char symbol = m->tape[m->pointer]; Branch branch = c.branches[branchIndex];
 
-      // Here we are checking whether or not we are in the correct branch
-      // if we are not, we will go on to the next iteration.
-      // If we are, we will execute the branch and move on to the next
-      // configuration
-      if (branch.matchSymbol != ELSE && branch.matchSymbol != symbol) {
-        continue;
-      }
-      // For printing purposes
-      m->branch = branchIndex;
+            // Here we are checking whether or not we are in the correct branch
+            // if we are not, we will go on to the next iteration.
+            // If we are, we will execute the branch and move on to the next
+            // configuration
+            if (branch.matchSymbol != symbol) {
+                continue;
+            }
+            // For printing purposes
+            m->branch = branchIndex;
 
-      // Execute all operations in branch until a N
-      bool nop = false;
-      for (int operationIndex = 0; operationIndex < MAX_OPERATION_COUNT;
-           ++operationIndex) {
-        Operation operation = branch.operations[operationIndex];
-        switch (operation.op) {
-          case N: {
-            nop = true;
-          } break;
-          case P: {
-            print(m, operation.parameter.string);
-          } break;
-          case E: {
-            erase(m);
-          } break;
-          case R: {
-            right(m, operation.parameter.number);
-          } break;
-          case L: {
-            left(m, operation.parameter.number);
-          } break;
+            // Execute all operations in branch until a N
+            bool nop = false;
+            for (int operationIndex = 0; operationIndex < MAX_OPERATION_COUNT;
+                    ++operationIndex) {
+                Operation operation = branch.ops[operationIndex];
+                switch (operation.name) {
+                    case N: {
+                                nop = true;
+                            } break;
+                    case P: {
+                                print(m, operation.string);
+                            } break;
+                    case E: {
+                                erase(m);
+                            } break;
+                    case R: {
+                                right(m, operation.number);
+                            } break;
+                    case L: {
+                                left(m, operation.number);
+                            } break;
+                }
+                if (nop) {
+                    break;
+                }
+            }
+
+            // Change topPointerAccessed if we have
+            // touched a higher pointer.
+            // This is for printing purposes.
+            if (m->pointer > topPointerAccessed) {
+                topPointerAccessed = m->pointer;
+            }
+            // Adjust the window of the tape to print
+            // if we move out of the defined boundaries
+            if (m->pointer >= highBound || m->pointer <= lowBound) {
+                if (topPointerAccessed - m->pointer >= window / 2) {
+                    printf("more");
+                    highBound = m->pointer + window / 2;
+                    lowBound = m->pointer - window / 2;
+                } else {
+                    highBound = topPointerAccessed + 1;
+                    lowBound = highBound - window;
+                }
+            }
+            /*
+            if (verbose) {
+                PrintMachine(m, topPointerAccessed, lowBound, highBound,
+                true);
+            }
+            */
+            m->configuration = branch.nextConfiguration;
+            break;
         }
-        if (nop) {
-          break;
-        }
-      }
-
-      // Change topPointerAccessed if we have
-      // touched a higher pointer.
-      // This is for printing purposes.
-      if (m->pointer > topPointerAccessed) {
-        topPointerAccessed = m->pointer;
-      }
-      // Adjust the window of the tape to print
-      // if we move out of the defined boundaries
-      if (m->pointer >= highBound || m->pointer <= lowBound) {
-        if (topPointerAccessed - m->pointer >= window / 2) {
-          printf("more");
-          highBound = m->pointer + window / 2;
-          lowBound = m->pointer - window / 2;
-        } else {
-          highBound = topPointerAccessed + 1;
-          lowBound = highBound - window;
-        }
-      }
-
-      if (verbose) {
-        // PrintMachine(m, topPointerAccessed, lowBound, highBound, true);
-      }
-      m->configuration = branch.nextConfiguration;
-      break;
     }
-  }
 
-  // Here we want to print the result of the computation
-  // into a buffer for printing.
-  // We do this by writing every second value from the turing
-  // machine's tape into the result buffer (following turing's
-  // conventions).
+    // Here we want to print the result of the computation
+    // into a buffer for printing.
+    // We do this by writing every second value from the turing
+    // machine's tape into the result buffer (following turing's
+    // conventions).
 
-  int maxIndex = 2 * (int)floor(topPointerAccessed / 2) + 2;
-  int resultIndex = 0;
-  for (int tapeIndex = 0; tapeIndex < maxIndex; tapeIndex += 2) {
-    result[resultIndex++] = m->tape[tapeIndex];
-  }
+    int maxIndex = 2 * (int)floor(topPointerAccessed / 2) + 2;
+    int resultIndex = 0;
+    for (int tapeIndex = 0; tapeIndex < maxIndex; tapeIndex += 2) {
+        result[resultIndex++] = m->tape[tapeIndex];
+    }
 }
 
-Machine translate(IR ir) {
-  /*
-   * Iterer over konfigurasjoner i ir.configs
-   * For hver, legg til alle branches i ir.configs[i].branches
-   * For hver branch, legg til alle operasjoner.
-   * Legg til 'next' sin indeks ved find(ir.configs[i].next.name);
-   *
-   */
+Machine translate(IR *ir) {
+    Machine m;
 
-  // TODO TODO TODO this is the translation to bytecode, must be done later
-  /*
-     if (strcmp(symbol, "none") == 0) {
-     branch->matchSymbol = NONE;
-     } else if (strcmp(symbol, "else") == 0) {
-     branch->matchSymbol = ELSE;
-     } else {
-     branch->matchSymbol = *symbol;
-     }
+    for (int ci = 0; ci < ir->configCount; ci++) {
+        Configuration *conf = &m.configurations[ci];
+        IConfig iconf = ir->configs[ci];
 
-  // TODO Error handling during this parsing...
-  // TODO Parameter is no longer varParameter, but
-  // parameter.num or parameter.string
-  // TODO Also handle bool op.isnum
-  char *ops[MAX_OPERATION_COUNT] = {0};
-  int opCount = splitOn(ops, opsString, operationDelim);
+        // Iterate over each branch in each configuration
+        // and fill in its information from the ir
+        for (int bi = 0; bi < iconf.branchCount; bi++) {
+            Branch *branch = &conf->branches[bi];
+            IBranch ibranch = iconf.branches[bi];
 
-  for (int i = 0; i < opCount; ++i) {
-  char *op = trim(ops[i]);
-  if (*op == 'N') {
-  b->operations[i].op = N;
-  } else if (*op == 'P') {
-  b->operations[i].op = P;
-  strcpy(b->operations[i].varParameter, (op + 1));
-  } else if (*op == 'E') {
-  b->operations[i].op = E;
-  } else if (*op == 'R') {
-  b->operations[i].op = R;
-  // TODO assert that param is a number
-  char param = *(op + 1);
-  if (param == ',' || param == 0) {
-  b->operations[i].parameter = 1;
-  } else {
-  b->operations[i].parameter = param - 48;
-  }
-  } else if (*op == 'L') {
-  b->operations[i].op = L;
-  // TODO assert that param is a number
-  char param = *(op + 1);
-  if (param == ',' || param == 0) {
-  b->operations[i].parameter = 1;
-  } else {
-  b->operations[i].parameter = param - 48;
-  }
-  } else {
-  // TODO Error: invalid function name.
-  }
-  }
-  */
+            // Set the value for the match symbol,
+            // translating keywords into their correlated value.
+            if (strcmp(ibranch.matchSymbol, "none") == 0) {
+                branch->matchSymbol = NONE;
+            } else if (strcmp(ibranch.matchSymbol, "any") == 0) {
+                branch->matchSymbol = ANY;
+            } else if (strcmp(ibranch.matchSymbol, "else") == 0) {
+                branch->matchSymbol = ELSE;
+            } else {
+                branch->matchSymbol = ibranch.matchSymbol[0];
+            }
 
-  /*
-  // TODO actually make the bytecode.
-  Machine m = {0};
-  for (int i = 0; i < TAPE_LENGTH; i++) {
-  m.tape[i] = ' ';
-  }
-  return m;
-  */
+            // Determine the index of the next configuration
+            // by iterating over the configurations and finding
+            // the one with the correct name.
+            for (int ci = 0; ci < ir->configCount; ci++) {
+                if (ibranch.next->name == ir->configs[ci].name) {
+                    branch->nextConfiguration = ci;
+                }
+            }
 
-  Machine m;
-  return m;
+            // Fill in the operations for the current branch
+            for (int oi = 0; oi < ibranch.opCount; oi++) {
+                Operation *op = &branch->ops[oi];
+                IOperation iop = ibranch.ops[oi];
+                switch (iop.name) {
+                    case 'N': {
+                                  op->name = N;
+                              } break;
+                    case 'E': {
+                                  op->name = E;
+                              } break;
+                    case 'P': {
+                                  op->name = P;
+                                  op->string = iop.string;
+                              } break;
+                    case 'R': {
+                                  op->name = R;
+                                  op->number = iop.number;
+                              } break;
+                    case 'L': {
+                                  op->name = L;
+                                  op->number = (int)iop.number;
+                              } break;
+                }
+            }
+        }
+    }
+    return m;
 }
 
 int main(int argc, char *argv[]) {
-  Context c = {0};
+    Context c = {0};
 
-  int timesToRun = -1;
-  char *filename = 0;
-  bool verbose = false;
+    int timesToRun = -1;
+    char *filename = 0;
+    bool verbose = false;
 
-  for (int i = 1; i < argc; ++i) {
-    if (is_number(argv[i])) {
-      char *endPtr;
-      timesToRun = strtol(argv[i], &endPtr, 10);
-    } else if (*argv[i] == '-') {
-      if (*(argv[i] + 1) == 'v') {
-        verbose = true;
-      }
+    for (int i = 1; i < argc; ++i) {
+        if (is_number(argv[i])) {
+            char *endPtr;
+            timesToRun = strtol(argv[i], &endPtr, 10);
+        } else if (*argv[i] == '-') {
+            if (*(argv[i] + 1) == 'v') {
+                verbose = true;
+            }
 
-    } else if (!filename) {
-      filename = argv[i];
+        } else if (!filename) {
+            filename = argv[i];
+        }
     }
-  }
 
-  if (filename == 0) {
-    error(&c, "no filename specified", FILE_ERROR);
-  }
+    if (filename == 0) {
+        error(&c, "no filename specified", FILE_ERROR);
+    }
 
-  if (timesToRun == -1) {
-    error(&c, "please specify number of passes to make", FILE_ERROR);
-  }
+    if (timesToRun == -1) {
+        error(&c, "please specify number of passes to make", FILE_ERROR);
+    }
 
-  //  char result[256] = {0};
+    char *bytecode = read_source(&c, filename);
 
-  char *bytecode = read_source(&c, filename);
+    IR ir = {0};
 
-  IR ir = {0};  //(IR *)malloc(sizeof(IR));
+    parse(&c, &ir, bytecode);
+    Machine m = translate(&ir);
 
-  parse(&c, &ir, bytecode);
-  // Machine m = translate(ir);
-  /*  run_machine(&c, &m, timesToRun, result, verbose);
+    char result[256];
+    run_machine(&c, &m, timesToRun, result, verbose);
 
-      char stringResult[256];
-      parse_string(stringResult, result);
+    char stringResult[256];
+    parse_string(stringResult, result);
 
-      float floatResult = parse_binary_point_value(result);
+    float floatResult = parse_binary_point_value(result);
 
-  // Print interpretations of the result
-  printf("\nBinary:\t%s\nString:\t%s\nFloat:\t%f\n", result, stringResult,
-  floatResult);
-  */
+    // Print interpretations of the result
+    printf("\nBinary:\t%s\nString:\t%s\nFloat:\t%f\n", result, stringResult,
+            floatResult);
 
-  return 0;
+    return 0;
 }

--- a/alan.h
+++ b/alan.h
@@ -1,0 +1,21 @@
+#ifndef ALAN_H
+#define ALAN_H
+
+typedef struct Machine Machine;
+typedef struct Configuration Configuration;
+typedef struct Branch Branch;
+typedef struct Operation Operation;
+
+typedef struct IOperation IOperation;
+typedef struct IBranch IBranch;
+typedef struct IConfig IConfig;
+typedef struct IR IR;
+
+typedef struct Error Error;
+typedef struct Context Context;
+
+IR *parse(Context *context, IR *ir, char *bytecode);
+Machine translate(IR ir);
+void run_machine(Context *context, Machine *m, int iterations, char *result, bool verbose);
+
+#endif

--- a/alan.h
+++ b/alan.h
@@ -15,7 +15,7 @@ typedef struct Error Error;
 typedef struct Context Context;
 
 IR *parse(Context *context, IR *ir, char *bytecode);
-Machine translate(IR ir);
+Machine translate(IR *ir);
 void run_machine(Context *context, Machine *m, int iterations, char *result, bool verbose);
 
 #endif


### PR DESCRIPTION
The core has been rewritten.
The parser now produces an abstract representation containing some metadata about the source code, which closes #39

The pretty printer is fixed and utilities the metadata in the abstract representation. The bytecode contains a reference to the metadata versions of each type, in order to solve some runtime issues. Not sure if this is actually a good solution, but it closes #38.

In the rewriting, a lot of hardcoded arrays were changed to just be pointers to strings. This closes #34

Finally, we swiftly added the 'any' keyword. This closes #36.